### PR TITLE
Add storm debris config

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/ProjectAtmosphere.java
+++ b/src/main/java/net/Gabou/projectatmosphere/ProjectAtmosphere.java
@@ -10,6 +10,7 @@ import net.Gabou.projectatmosphere.compat.SimpleCloudsCompat;
 import net.Gabou.projectatmosphere.manager.ForecastGenerator;
 import net.Gabou.projectatmosphere.registry.*;
 import net.Gabou.projectatmosphere.manager.AtmosphereManager;
+import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
 import net.Gabou.projectatmosphere.util.AsyncAtmosphereService;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -29,6 +30,8 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.config.ModConfigEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.ModLoadingContext;
+import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
@@ -54,6 +57,8 @@ public class ProjectAtmosphere {
     public ProjectAtmosphere() {
         LOGGER.info("Project Atmosphere is loading!");
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+
+        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, AtmoCommonConfig.COMMON_SPEC);
 
         CompatHandler.init();
         ModItems.register(modEventBus);

--- a/src/main/java/net/Gabou/projectatmosphere/blocks/BlockManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/blocks/BlockManager.java
@@ -3,6 +3,7 @@ package net.Gabou.projectatmosphere.blocks;
 import net.Gabou.projectatmosphere.manager.ForecastGenerator;
 import net.Gabou.projectatmosphere.modules.core.WindVector;
 import net.Gabou.projectatmosphere.registry.ModBlocks;
+import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
 import net.Gabou.projectatmosphere.util.AsyncAtmosphereService;
 import net.Gabou.projectatmosphere.util.AtmosphereUtils;
 import net.minecraft.core.BlockPos;
@@ -98,7 +99,11 @@ public class BlockManager {
 
 
     public static void spawnCochonnerie(ServerLevel level, BlockPos centerPos) {
-        final int ENTITY_THRESHOLD = 50;
+        if (!AtmoCommonConfig.ENABLE_STORM_DEBRIS.get()) {
+            return;
+        }
+
+        int ENTITY_THRESHOLD = AtmoCommonConfig.MAX_STORM_DEBRIS_PER_CHUNK.get();
 
         // Get bounding box of the chunk containing centerPos
         ChunkPos chunkPos = new ChunkPos(centerPos);
@@ -110,13 +115,18 @@ public class BlockManager {
         // Count item entities inside the chunk
         long itemCount = level.getEntitiesOfClass(ItemEntity.class, chunkBox).size();
 
-        if (itemCount > ENTITY_THRESHOLD) {
+        if (itemCount >= ENTITY_THRESHOLD) {
             System.out.println("[Atmosphere] Skipping debris spawn — too many items in chunk at " + chunkPos);
             return;
         }
 
         RandomSource random = level.getRandom();
         int debrisCount = 3 + random.nextInt(5);
+        int allowedSpawn = Math.max(0, ENTITY_THRESHOLD - (int) itemCount);
+        if (allowedSpawn <= 0) {
+            return;
+        }
+        debrisCount = Math.min(debrisCount, allowedSpawn);
 
         for (int i = 0; i < debrisCount; i++) {
             double dx = centerPos.getX() + random.nextGaussian() * 5;

--- a/src/main/java/net/Gabou/projectatmosphere/config/AtmoCommonConfig.java
+++ b/src/main/java/net/Gabou/projectatmosphere/config/AtmoCommonConfig.java
@@ -18,6 +18,8 @@ import java.util.stream.Collectors;
 
 public class AtmoCommonConfig {
     public static final ForgeConfigSpec.BooleanValue FORCE_SHARED_EXECUTOR;
+    public static final ForgeConfigSpec.BooleanValue ENABLE_STORM_DEBRIS;
+    public static final ForgeConfigSpec.IntValue MAX_STORM_DEBRIS_PER_CHUNK;
 
     static {
         ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
@@ -25,6 +27,14 @@ public class AtmoCommonConfig {
         FORCE_SHARED_EXECUTOR = builder
                 .comment("Force use of shared executor for all async tasks, regardless of CPU count")
                 .define("forceSharedExecutor", false);
+        builder.pop();
+        builder.push("storms");
+        ENABLE_STORM_DEBRIS = builder
+                .comment("Enable random debris spawning during storms")
+                .define("enableStormDebris", true);
+        MAX_STORM_DEBRIS_PER_CHUNK = builder
+                .comment("Maximum number of storm debris items allowed per chunk")
+                .defineInRange("maxStormDebrisPerChunk", 100, 0, Integer.MAX_VALUE);
         builder.pop();
         COMMON_SPEC = builder.build();
     }


### PR DESCRIPTION
## Summary
- allow disabling storm debris and setting per-chunk limit via `AtmoCommonConfig`
- register common config on mod load
- gate storm debris spawn based on config and enforce per-chunk limit

## Testing
- `gradle build` *(fails: Plugin not found due to restricted network access)*

------
https://chatgpt.com/codex/tasks/task_e_688a79fef49c8331be4ec3409c40f0a5