### PR TITLE
Update AGENTS for JDK 17

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,4 +11,5 @@ This repository hosts **Project Atmosphere**, a Minecraft Forge 1.20.1 mod writt
 - The project uses Gradle. The wrapper is not included, so use the system `gradle` command.
 - Run `gradle build` from the repository root after any changes. This is the current programmatic check. The build may fail if external dependencies cannot be resolved.
 - No test suite exists yet.
+- Build with **JDK 17**. Ensure the PATH and `java` command reference JDK 17 before running Gradle.
 


### PR DESCRIPTION
## Summary
- document that builds must use JDK 17

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_688b671b5c8883318eeba059191f5f3e