### PR TITLE
Optimize login tasks

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/manager/AtmosphereManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/manager/AtmosphereManager.java
@@ -84,13 +84,14 @@ public class AtmosphereManager {
 
 
     public static void onPlayerLogin(ServerLevel world, ServerPlayer player) {
-        CompletableFuture<Void> future = new CompletableFuture<>();
         UUID uuid = player.getUUID();
+        CompletableFuture<Void> future = new CompletableFuture<>();
         playerReadyMap.put(uuid, future);
-        ForecastOrchestrator.onPlayerLogin(player, world);
-        future.complete(null); // ✅ débloque le login
 
-
+        world.getServer().execute(() -> {
+            ForecastOrchestrator.onPlayerLogin(player, world);
+            future.complete(null);
+        });
     }
 
 

--- a/src/main/java/net/Gabou/projectatmosphere/manager/ForecastOrchestrator.java
+++ b/src/main/java/net/Gabou/projectatmosphere/manager/ForecastOrchestrator.java
@@ -47,18 +47,22 @@ public class ForecastOrchestrator {
         UUID uuid = player.getUUID();
         BlockPos playerPos = player.blockPosition();
 
-        // Check if already known
         if (!ForecastDataStorage.playerData.containsKey(uuid)) {
-            // Check if far from all known centers
-            boolean shouldGenerate = ForecastDataStorage.playerData.values().stream()
-                    .allMatch(center -> center.distManhattan(playerPos) >= MIN_DISTANCE_BETWEEN_CENTERS);
+            boolean shouldGenerate = true;
+            for (BlockPos center : ForecastDataStorage.playerData.values()) {
+                if (center.distManhattan(playerPos) < MIN_DISTANCE_BETWEEN_CENTERS) {
+                    shouldGenerate = false;
+                    break;
+                }
+            }
 
             if (shouldGenerate) {
                 ForecastDataStorage.playerData.put(uuid, playerPos);
-                SimpleCloudsCompat.doInitialGenWithWeather(player.blockPosition().getX(), player.blockPosition().getZ(), level);
+                SimpleCloudsCompat.doInitialGenWithWeather(playerPos.getX(), playerPos.getZ(), level);
             }
+        } else {
+            SimpleCloudsCompat.isInit = true;
         }
-        else SimpleCloudsCompat.isInit = true;
     }
 
     /**


### PR DESCRIPTION
## Summary
- handle login tasks after the event using `Server#execute`
- avoid stream overhead when validating player distance
- reuse computed player position

## Testing
- `gradle build` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688b97c109308331b87ab157ed18575d