### PR TITLE
Fix average forecast daily data generation

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/manager/ForecastGenerator.java
+++ b/src/main/java/net/Gabou/projectatmosphere/manager/ForecastGenerator.java
@@ -280,6 +280,8 @@ public class ForecastGenerator {
         computeAverageStormChance();
         // 8. Génération courbes journalières
         DailyForecastGenerator.scheduleAll(level, FORECAST_MAP);
+        // Recompute averages now that daily profiles are available
+        computeAverageForecastsByBiomeType();
         long end = System.nanoTime(); // End timer
         long durationMs = (end - start) / 1_000_000;
         ProjectAtmosphere.LOGGER.info("[Atmosphere] Forecast region generation took " + durationMs + " ms.");


### PR DESCRIPTION
## Summary
- recompute biome average forecasts after daily profiles are generated

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_688bef3dd4a8833188a1b74fe66de7cb