### PR TITLE
Adjust debris spawn rate

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/config/AtmoCommonConfig.java
+++ b/src/main/java/net/Gabou/projectatmosphere/config/AtmoCommonConfig.java
@@ -34,7 +34,7 @@ public class AtmoCommonConfig {
                 .define("enableStormDebris", true);
         MAX_STORM_DEBRIS_PER_CHUNK = builder
                 .comment("Maximum number of storm debris items allowed per chunk")
-                .defineInRange("maxStormDebrisPerChunk", 100, 0, Integer.MAX_VALUE);
+                .defineInRange("maxStormDebrisPerChunk", 30, 0, Integer.MAX_VALUE);
         builder.pop();
         COMMON_SPEC = builder.build();
     }

--- a/src/main/java/net/Gabou/projectatmosphere/event/EventHandler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/event/EventHandler.java
@@ -24,7 +24,9 @@ import static net.Gabou.projectatmosphere.ProjectAtmosphere.LOGGER;
 public class EventHandler {
 
     private static final int MIN_TICKS_BETWEEN_DUST_SPAWN = 5000;
-    private static final int MIN_TICKS_BETWEEN_TEMPESTA = 1000;
+    // Increase delay between tempest effects to reduce how often
+    // cochonerie (debris) spawns
+    private static final int MIN_TICKS_BETWEEN_TEMPESTA = 2000;
 
     private static int tickCounter = 0;
 


### PR DESCRIPTION
## Summary
- slow down tempest spawning to reduce cochonerie frequency
- lower default storm debris cap from 100 to 30

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_688cc5cac9448331b6bf789123956a9d