### PR TITLE
Refactor deprecated APIs

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/ProjectAtmosphere.java
+++ b/src/main/java/net/Gabou/projectatmosphere/ProjectAtmosphere.java
@@ -30,7 +30,6 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.config.ModConfigEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -55,11 +54,11 @@ public class ProjectAtmosphere {
     public static final String MODID = "projectatmosphere";
     public static final Logger LOGGER = LogManager.getLogger(MODID);
 
-    public ProjectAtmosphere() {
+    public ProjectAtmosphere(FMLJavaModLoadingContext context) {
         LOGGER.info("Project Atmosphere is loading!");
-        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+        IEventBus modEventBus = context.getModEventBus();
 
-        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, AtmoCommonConfig.COMMON_SPEC);
+        context.registerConfig(ModConfig.Type.COMMON, AtmoCommonConfig.COMMON_SPEC);
 
         CompatHandler.init();
         ModItems.register(modEventBus);

--- a/src/main/java/net/Gabou/projectatmosphere/client/TornadoShaders.java
+++ b/src/main/java/net/Gabou/projectatmosphere/client/TornadoShaders.java
@@ -19,7 +19,7 @@ public class TornadoShaders {
     @SubscribeEvent
     public static void onRegisterShaders(RegisterShadersEvent event) throws IOException {
         ShaderInstance shader = new ShaderInstance(event.getResourceProvider(),
-                new ResourceLocation(ProjectAtmosphere.MODID, "tornado"), DefaultVertexFormat.POSITION);
+                ResourceLocation.fromNamespaceAndPath(ProjectAtmosphere.MODID, "tornado"), DefaultVertexFormat.POSITION);
         event.registerShader(shader, s -> tornadoShader = s);
     }
 

--- a/src/main/java/net/Gabou/projectatmosphere/event/BiomeChangeManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/event/BiomeChangeManager.java
@@ -48,7 +48,7 @@ public class BiomeChangeManager {
                 .getBiome(pos)
                 .unwrapKey()
                 .map(ResourceKey::location)
-                .orElse(new ResourceLocation("minecraft", "plains"));
+                .orElse(ResourceLocation.fromNamespaceAndPath("minecraft", "plains"));
     }
 
     private static void onBiomeChanged(ServerPlayer player, ResourceLocation oldBiome, ResourceLocation newBiome) {

--- a/src/main/java/net/Gabou/projectatmosphere/modules/temperature/spike/SpikeStateStorage.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/temperature/spike/SpikeStateStorage.java
@@ -66,7 +66,7 @@ public class SpikeStateStorage {
                 for (Map.Entry<String, JsonElement> entry : root.entrySet()) {
                     JsonObject obj = entry.getValue().getAsJsonObject();
 
-                    ResourceLocation biome = new ResourceLocation(obj.get("biome").getAsString());
+                    ResourceLocation biome = ResourceLocation.parse(obj.get("biome").getAsString());
                     BlockPos pos = AtmosphereUtils.deserializeBlockPos(obj.get("pos").getAsJsonObject());
 
                     BiomeInstanceKey key = new BiomeInstanceKey(biome, pos);

--- a/src/main/java/net/Gabou/projectatmosphere/network/NetworkHandler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/network/NetworkHandler.java
@@ -9,7 +9,7 @@ import net.minecraftforge.network.simple.SimpleChannel;
 public class NetworkHandler {
     private static final String PROTOCOL_VERSION = "1";
     public static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(
-            new ResourceLocation(ProjectAtmosphere.MODID, "main"),
+            ResourceLocation.fromNamespaceAndPath(ProjectAtmosphere.MODID, "main"),
             () -> PROTOCOL_VERSION,
             PROTOCOL_VERSION::equals,
             PROTOCOL_VERSION::equals

--- a/src/main/java/net/Gabou/projectatmosphere/util/BiomeInstanceKey.java
+++ b/src/main/java/net/Gabou/projectatmosphere/util/BiomeInstanceKey.java
@@ -17,7 +17,7 @@ public record BiomeInstanceKey(ResourceLocation biomeType, BlockPos samplePos) {
             String[] parts = s.split("@");
             if (parts.length != 2) throw new IllegalArgumentException("Invalid BiomeInstanceKey format: " + s);
 
-            ResourceLocation biome = new ResourceLocation(parts[0]);
+            ResourceLocation biome = ResourceLocation.parse(parts[0]);
             String[] posParts = parts[1].split(",");
 
             if (posParts.length != 3) throw new IllegalArgumentException("Invalid position format");
@@ -34,7 +34,7 @@ public record BiomeInstanceKey(ResourceLocation biomeType, BlockPos samplePos) {
     }
 
     public static BiomeInstanceKey fromJson(JsonObject obj) {
-        ResourceLocation biome = new ResourceLocation(obj.get("biome").getAsString());
+        ResourceLocation biome = ResourceLocation.parse(obj.get("biome").getAsString());
         BlockPos pos = AtmosphereUtils.deserializeBlockPos(obj.get("pos").getAsJsonObject());
         return new BiomeInstanceKey(biome, pos);
     }

--- a/src/main/java/net/Gabou/projectatmosphere/util/StorageUtils.java
+++ b/src/main/java/net/Gabou/projectatmosphere/util/StorageUtils.java
@@ -24,7 +24,7 @@ public class StorageUtils {
                 JsonObject root = gson.fromJson(r, JsonObject.class);
                 for (var entry : root.entrySet()) {
                     JsonObject obj = entry.getValue().getAsJsonObject();
-                    ResourceLocation biome = new ResourceLocation(obj.get("biome").getAsString());
+                    ResourceLocation biome = ResourceLocation.parse(obj.get("biome").getAsString());
                     BlockPos pos = AtmosphereUtils.deserializeBlockPos(obj.get("pos").getAsJsonObject());
                     JsonArray arr = obj.get("data").getAsJsonArray();
                     float[][] week = new float[7][2];
@@ -46,7 +46,7 @@ public class StorageUtils {
             JsonObject root = gson.fromJson(r, JsonObject.class);
             for (var entry : root.entrySet()) {
                 JsonObject obj = entry.getValue().getAsJsonObject();
-                ResourceLocation biome = new ResourceLocation(obj.get("biome").getAsString());
+                ResourceLocation biome = ResourceLocation.parse(obj.get("biome").getAsString());
                 BlockPos pos = AtmosphereUtils.deserializeBlockPos(obj.get("pos").getAsJsonObject());
                 JsonArray arr = obj.get("data").getAsJsonArray();
                 float[] week = new float[7];


### PR DESCRIPTION
## Summary
- stop using deprecated FMLJavaModLoadingContext and ModLoadingContext accessors
- replace deprecated ResourceLocation constructors with current API

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_688e106a89cc8331ad44381cb53a1fc8