### PR TITLE
Add UV-based tornado shader with procedural animation

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/client/TornadoRenderHandler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/client/TornadoRenderHandler.java
@@ -63,14 +63,30 @@ public static void renderTornado(PoseStack stack, double x, double y, double z) 
     stack.translate(x, y, z);
     Matrix4f matrix = stack.last().pose();
 
-    RenderSystem.setShader(() -> MyShaders.TORNADO);
+    ShaderInstance shader = MyShaders.TORNADO;
+    RenderSystem.setShader(() -> shader);
+    shader.apply();
+
+    var modelView = shader.getUniform("ModelViewMat");
+    if (modelView != null) {
+        modelView.set(matrix);
+    }
+    var projMat = shader.getUniform("ProjMat");
+    if (projMat != null) {
+        projMat.set(RenderSystem.getProjectionMatrix());
+    }
+    var timeUniform = shader.getUniform("Time");
+    if (timeUniform != null) {
+        timeUniform.set(TornadoManager.getShaderTime());
+    }
+
     RenderSystem.enableBlend();
     RenderSystem.defaultBlendFunc();
     RenderSystem.disableCull(); // See both sides
 
     Tesselator tess = Tesselator.getInstance();
     BufferBuilder buffer = tess.getBuilder();
-    buffer.begin(VertexFormat.Mode.TRIANGLE_STRIP, DefaultVertexFormat.POSITION);
+    buffer.begin(VertexFormat.Mode.TRIANGLE_STRIP, DefaultVertexFormat.POSITION_TEX);
 
     int segments = 64;
     int rings = 30;
@@ -90,14 +106,15 @@ public static void renderTornado(PoseStack stack, double x, double y, double z) 
 
         for (int j = 0; j <= segments; j++) {
             float angle = (float) (2 * Math.PI * j / segments);
+            float u = j / (float) segments;
 
             float x0 = (float) (radius0 * Math.cos(angle + twist0));
             float z0 = (float) (radius0 * Math.sin(angle + twist0));
             float x1 = (float) (radius1 * Math.cos(angle + twist1));
             float z1 = (float) (radius1 * Math.sin(angle + twist1));
 
-            buffer.vertex(matrix, x0, y0, z0).endVertex();
-            buffer.vertex(matrix, x1, y1, z1).endVertex();
+            buffer.vertex(matrix, x0, y0, z0).uv(u, y0 / height).endVertex();
+            buffer.vertex(matrix, x1, y1, z1).uv(u, y1 / height).endVertex();
         }
     }
 

--- a/src/main/java/net/Gabou/projectatmosphere/client/TornadoShaders.java
+++ b/src/main/java/net/Gabou/projectatmosphere/client/TornadoShaders.java
@@ -19,7 +19,7 @@ public class TornadoShaders {
     @SubscribeEvent
     public static void onRegisterShaders(RegisterShadersEvent event) throws IOException {
         ShaderInstance shader = new ShaderInstance(event.getResourceProvider(),
-                ResourceLocation.fromNamespaceAndPath(ProjectAtmosphere.MODID, "tornado"), DefaultVertexFormat.POSITION);
+                ResourceLocation.fromNamespaceAndPath(ProjectAtmosphere.MODID, "tornado"), DefaultVertexFormat.POSITION_TEX);
         event.registerShader(shader, s -> MyShaders.TORNADO = s);
     }
 

--- a/src/main/resources/assets/projectatmosphere/shaders/core/tornado.fsh
+++ b/src/main/resources/assets/projectatmosphere/shaders/core/tornado.fsh
@@ -1,13 +1,51 @@
 #version 150
 
+in vec2 texCoord;
 uniform float Time;
 
 out vec4 fragColor;
 
-void main() {
-    // Simulate smoke-like grayscale
-    float swirl = sin(gl_FragCoord.y * 0.1 + Time * 2.0) * 0.1;
-    float brightness = 0.3 + swirl;
+vec3 mod289(vec3 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+vec2 mod289(vec2 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+vec3 permute(vec3 x) { return mod289((x * 34.0 + 1.0) * x); }
 
-    fragColor = vec4(vec3(brightness), 0.9); // smoky gray with slight alpha
+float snoise(vec2 v) {
+    const vec4 C = vec4(0.211324865, 0.366025403, -0.577350269, 0.0243902439);
+    vec2 i = floor(v + dot(v, C.yy));
+    vec2 x0 = v - i + dot(i, C.xx);
+    vec2 i1 = (x0.x > x0.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+    vec4 x12 = x0.xyxy + C.xxzz; x12.xy -= i1;
+    vec3 p0 = vec3(x0, 0.0); vec3 p1 = vec3(x12.xy, 0.0); vec3 p2 = vec3(x12.zw, 0.0);
+    i = mod289(i);
+    vec3 perm = permute(permute(i.y + vec3(0.0, i1.y, 1.0)) + i.x + vec3(0.0, i1.x, 1.0));
+    vec3 m = max(0.5 - vec3(dot(p0,p0), dot(p1,p1), dot(p2,p2)), 0.0);
+    m = m * m * m * m;
+    vec3 x = 2.0 * fract(perm * C.www) - 1.0;
+    vec3 h = abs(x) - 0.5; vec3 ox = floor(x + 0.5); vec3 a0 = x - ox;
+    m *= 1.79284291400159 - 0.85373472095314 * (a0*a0 + h*h);
+    vec3 g;
+    g.x = a0.x * p0.x + h.x * p0.y;
+    g.y = a0.y * p1.x + h.y * p1.y;
+    g.z = a0.z * p2.x + h.z * p2.y;
+    return 130.0 * dot(m, g);
+}
+
+void main() {
+    vec2 uv = texCoord;
+    vec2 center = vec2(0.5, 0.5);
+    vec2 pos = uv - center;
+
+    float angle = Time * 1.5;
+    float s = sin(angle);
+    float c = cos(angle);
+    mat2 rot = mat2(c, -s, s, c);
+    pos = rot * pos;
+    pos += center;
+    pos.y += Time * 0.25;
+
+    float noiseVal = snoise(pos * 5.0);
+    float alpha = smoothstep(0.2, 0.5, noiseVal);
+    float fadeTop = smoothstep(1.0, 0.6, uv.y);
+
+    fragColor = vec4(vec3(0.2, 0.2, 0.2), alpha * fadeTop);
 }

--- a/src/main/resources/assets/projectatmosphere/shaders/core/tornado.json
+++ b/src/main/resources/assets/projectatmosphere/shaders/core/tornado.json
@@ -1,7 +1,7 @@
 {
   "vertex": "projectatmosphere:tornado",
   "fragment": "projectatmosphere:tornado",
-  "attributes": ["Position"],
+  "attributes": ["Position", "UV0"],
   "uniforms": [
     {"name": "ModelViewMat", "type": "matrix4x4", "count": 16, "values": [1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0]},
     {"name": "ProjMat", "type": "matrix4x4", "count": 16, "values": [1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0]},

--- a/src/main/resources/assets/projectatmosphere/shaders/core/tornado.vsh
+++ b/src/main/resources/assets/projectatmosphere/shaders/core/tornado.vsh
@@ -1,13 +1,15 @@
 #version 150
 
 in vec3 Position;
+in vec2 UV0;
 
 uniform mat4 ModelViewMat;
 uniform mat4 ProjMat;
 uniform float Time;
 
+out vec2 texCoord;
+
 void main() {
-    vec3 animatedPos = Position;
-    animatedPos.y += sin(Time * 3.0) * 0.1; // subtle vertical wave
-    gl_Position = ProjMat * ModelViewMat * vec4(animatedPos, 1.0);
+    texCoord = UV0;
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 }


### PR DESCRIPTION
## Summary
- send UV coordinates for tornado mesh and set shader uniforms for model, projection, and time
- implement vertex and fragment shaders using UV space and animated noise for spinning smoke effect
- register tornado shader with POSITION_TEX format

## Testing
- `gradle build` *(fails: Plugin [id: 'org.gradle.toolchains.foojay-resolver-convention'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892a3252c78833192aa8991b295136d