### PR TITLE
Require sneaking to place instrument blocks

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/items/InstrumentBlockItem.java
+++ b/src/main/java/net/Gabou/projectatmosphere/items/InstrumentBlockItem.java
@@ -1,7 +1,6 @@
 package net.Gabou.projectatmosphere.items;
 
 import net.Gabou.projectatmosphere.blocks.InstrumentReader;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
@@ -9,10 +8,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
-import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.phys.BlockHitResult;
 
 public abstract class InstrumentBlockItem extends BlockItem implements InstrumentReader {
     public InstrumentBlockItem(Block block, Properties properties) {
@@ -22,8 +19,10 @@ public abstract class InstrumentBlockItem extends BlockItem implements Instrumen
     @Override
     public InteractionResult useOn(UseOnContext context) {
         Player player = context.getPlayer();
-        if (player != null && !player.isShiftKeyDown() && context.getLevel().isClientSide) {
-            display(context.getLevel(), player); // show HUD
+        if (player != null && !player.isShiftKeyDown()) {
+            if (context.getLevel().isClientSide) {
+                display(context.getLevel(), player); // show HUD
+            }
             return InteractionResult.SUCCESS;
         }
         // Shift + right-click = place block as usual
@@ -34,8 +33,10 @@ public abstract class InstrumentBlockItem extends BlockItem implements Instrumen
     @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
         // Optional: handle right-click in air
-        if (!player.isShiftKeyDown() && level.isClientSide) {
-            display(level, player);
+        if (!player.isShiftKeyDown()) {
+            if (level.isClientSide) {
+                display(level, player);
+            }
             return InteractionResultHolder.success(player.getItemInHand(hand));
         }
         return super.use(level, player, hand);


### PR DESCRIPTION
## Summary
- ensure instrument items only place blocks when sneaking
- keep HUD display when used without sneaking

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_6892a5af12a083318fa2534612445ccb