### PR TITLE
Optimize TAN temperature fetch

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/compat/ToughAsNailsCompat.java
+++ b/src/main/java/net/Gabou/projectatmosphere/compat/ToughAsNailsCompat.java
@@ -3,11 +3,9 @@ package net.Gabou.projectatmosphere.compat;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
-import net.minecraftforge.fml.ModList;
-import toughasnails.api.temperature.TemperatureHelper;
 import toughasnails.api.temperature.TemperatureLevel;
+import toughasnails.temperature.TemperatureHelperImpl;
 
 public class ToughAsNailsCompat {
 
@@ -20,7 +18,7 @@ public class ToughAsNailsCompat {
      */
     public static float[][] injectForecastForTAN(BiomeInstanceKey key, ServerLevel level) {
         BlockPos sample = key.samplePos();
-        TemperatureLevel band = TemperatureHelper.getTemperatureAtPos(level, sample);
+        TemperatureLevel band = TemperatureHelperImpl.getTemperatureAtPosWithoutProximity(level, sample);
         float baseTemp = mapBandToTemperature(band);
         return generateMinMaxCurve(baseTemp, level.getRandom());
     }


### PR DESCRIPTION
## Summary
- Optimize TAN compatibility by using `TemperatureHelperImpl.getTemperatureAtPosWithoutProximity` instead of the slower proximity-aware API

## Testing
- `gradle build` *(fails: plugin `org.gradle.toolchains.foojay-resolver-convention` not found)*


------
https://chatgpt.com/codex/tasks/task_e_6892afdc501083318c1796510ca445c6