### PR TITLE
Add tornado debris particles that follow active tornadoes

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/client/ClientTickHandler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/client/ClientTickHandler.java
@@ -1,9 +1,11 @@
 package net.Gabou.projectatmosphere.client;
 
 import net.Gabou.projectatmosphere.ProjectAtmosphere;
+import net.Gabou.projectatmosphere.client.TornadoRenderHandler;
 import net.Gabou.projectatmosphere.manager.ForecastGenerator;
 import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
 import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.Gabou.projectatmosphere.modules.tornado.TornadoInstance;
 import net.Gabou.projectatmosphere.modules.tornado.TornadoManager;
 import net.Gabou.projectatmosphere.modules.wind.WindMath;
 import net.Gabou.projectatmosphere.registry.ModParticles;
@@ -41,9 +43,14 @@ public class ClientTickHandler {
 
         tickCounter++;
         TornadoManager.tick();
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.level != null && mc.level.getGameTime() % 2 == 0) {
+            for (TornadoInstance tornado : TornadoManager.getActiveTornadoes()) {
+                TornadoRenderHandler.spawnDebrisParticles(tornado, (ClientLevel) mc.level);
+            }
+        }
         if (tickCounter % 40 != 0) return; // Run every 20 ticks (1 second)
         AsyncAtmosphereService.runClient(() -> {
-            Minecraft mc = Minecraft.getInstance();
             if (mc.level == null || mc.player == null) return;
             if (random == null) {
                 random = mc.level.random;

--- a/src/main/java/net/Gabou/projectatmosphere/client/TornadoRenderHandler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/client/TornadoRenderHandler.java
@@ -5,10 +5,12 @@ import com.mojang.blaze3d.vertex.*;
 import dev.nonamecrackers2.simpleclouds.common.config.SimpleCloudsConfig;
 import net.Gabou.projectatmosphere.client.render.TornadoMesh;
 import net.Gabou.projectatmosphere.modules.tornado.TornadoInstance;
+import net.Gabou.projectatmosphere.modules.tornado.TornadoManager;
+import net.Gabou.projectatmosphere.particles.DebrisParticleData;
 import net.minecraft.client.Camera;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.ShaderInstance;
 import net.minecraft.world.phys.Vec3;
-import net.Gabou.projectatmosphere.modules.tornado.TornadoManager;
 import org.joml.Matrix4f;
 
 public class TornadoRenderHandler {
@@ -108,6 +110,18 @@ public static void renderTornado(PoseStack stack, double x, double y, double z) 
     RenderSystem.disableBlend();
     stack.popPose();
 }
+
+
+    public static void spawnDebrisParticles(TornadoInstance tornado, ClientLevel level) {
+        for (int i = 0; i < 10; i++) {
+            double radius = 2.5 + level.random.nextDouble() * 2.0;
+            double height = level.random.nextDouble() * 10.0;
+            float angularSpeed = 5f;
+
+            level.addParticle(new DebrisParticleData(tornado, radius, height, angularSpeed),
+                    tornado.position.x, tornado.position.y, tornado.position.z, 0, 0.01, 0);
+        }
+    }
 
 
 

--- a/src/main/java/net/Gabou/projectatmosphere/particles/DebrisParticle.java
+++ b/src/main/java/net/Gabou/projectatmosphere/particles/DebrisParticle.java
@@ -1,0 +1,74 @@
+package net.Gabou.projectatmosphere.particles;
+
+import net.Gabou.projectatmosphere.modules.tornado.TornadoInstance;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.particle.Particle;
+import net.minecraft.client.particle.ParticleProvider;
+import net.minecraft.client.particle.ParticleRenderType;
+import net.minecraft.client.particle.SpriteSet;
+import net.minecraft.client.particle.TextureSheetParticle;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Particle representing debris swirling around a tornado.
+ */
+public class DebrisParticle extends TextureSheetParticle {
+    private final WeakReference<TornadoInstance> tornadoRef;
+    private final double radius;
+    private final double baseY;
+    private final float angularSpeed;
+    private final float startAngle;
+
+    protected DebrisParticle(ClientLevel level, TornadoInstance tornado, double radius, double height, float angularSpeed) {
+        super(level, tornado.position.x, tornado.position.y + height, tornado.position.z, 0, 0, 0);
+        this.tornadoRef = new WeakReference<>(tornado);
+        this.radius = radius;
+        this.baseY = height;
+        this.angularSpeed = angularSpeed;
+        this.startAngle = level.random.nextFloat() * 360f;
+        this.lifetime = 40 + this.random.nextInt(20);
+        this.gravity = 0;
+        this.friction = 0.95f;
+        this.setSize(0.2f, 0.2f);
+    }
+
+    @Override
+    public void tick() {
+        TornadoInstance tornado = tornadoRef.get();
+        if (tornado == null) {
+            remove();
+            return;
+        }
+        float angle = startAngle + (tornado.getLifetimeSeconds() * 20 + this.age) * angularSpeed;
+        double rad = Math.toRadians(angle);
+        setPos(
+                tornado.position.x + Math.cos(rad) * radius,
+                tornado.position.y + baseY,
+                tornado.position.z + Math.sin(rad) * radius
+        );
+        this.yd += 0.02;
+        super.tick();
+    }
+
+    @Override
+    public ParticleRenderType getRenderType() {
+        return ParticleRenderType.PARTICLE_SHEET_TRANSLUCENT;
+    }
+
+    public static class Provider implements ParticleProvider<DebrisParticleData> {
+        private final SpriteSet sprites;
+
+        public Provider(SpriteSet sprites) {
+            this.sprites = sprites;
+        }
+
+        @Override
+        public Particle createParticle(DebrisParticleData data, ClientLevel level, double x, double y, double z, double vx, double vy, double vz) {
+            DebrisParticle particle = new DebrisParticle(level, data.tornado(), data.radius(), data.height(), data.angularSpeed());
+            particle.pickSprite(sprites);
+            return particle;
+        }
+    }
+}
+

--- a/src/main/java/net/Gabou/projectatmosphere/particles/DebrisParticleData.java
+++ b/src/main/java/net/Gabou/projectatmosphere/particles/DebrisParticleData.java
@@ -1,0 +1,45 @@
+package net.Gabou.projectatmosphere.particles;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.serialization.Codec;
+import net.Gabou.projectatmosphere.modules.tornado.TornadoInstance;
+import net.Gabou.projectatmosphere.registry.ModParticles;
+import net.minecraft.core.particles.ParticleOptions;
+import net.minecraft.core.particles.ParticleType;
+import net.minecraft.network.FriendlyByteBuf;
+
+/**
+ * Particle data for {@link DebrisParticle}.
+ * This implementation is client-only and does not support network or command serialization.
+ */
+public record DebrisParticleData(TornadoInstance tornado, double radius, double height, float angularSpeed) implements ParticleOptions {
+    public static final Codec<DebrisParticleData> CODEC = Codec.unit(new DebrisParticleData(null, 0, 0, 0));
+
+    public static final Deserializer<DebrisParticleData> DESERIALIZER = new Deserializer<>() {
+        @Override
+        public DebrisParticleData fromCommand(ParticleType<DebrisParticleData> type, StringReader reader) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DebrisParticleData fromNetwork(ParticleType<DebrisParticleData> type, FriendlyByteBuf buf) {
+            throw new UnsupportedOperationException();
+        }
+    };
+
+    @Override
+    public ParticleType<?> getType() {
+        return ModParticles.DEBRIS.get();
+    }
+
+    @Override
+    public void writeToNetwork(FriendlyByteBuf buf) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String writeToString() {
+        return "debris";
+    }
+}
+

--- a/src/main/java/net/Gabou/projectatmosphere/registry/ModClient.java
+++ b/src/main/java/net/Gabou/projectatmosphere/registry/ModClient.java
@@ -1,6 +1,7 @@
 package net.Gabou.projectatmosphere.registry;
 
 import net.Gabou.projectatmosphere.ProjectAtmosphere;
+import net.Gabou.projectatmosphere.particles.DebrisParticle;
 import net.Gabou.projectatmosphere.particles.WindLeafParticle;
 import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.core.particles.SimpleParticleType;
@@ -24,6 +25,7 @@ public class ModClient {
         register(event, ModParticles.HEART_VERT);
         register(event, ModParticles.HEART_JAUNE);
         register(event, ModParticles.HEART_ORANGE);
+        event.registerSpriteSet(ModParticles.DEBRIS.get(), DebrisParticle.Provider::new);
     }
 
     private static void register(RegisterParticleProvidersEvent event, RegistryObject<SimpleParticleType> particleType) {

--- a/src/main/java/net/Gabou/projectatmosphere/registry/ModParticles.java
+++ b/src/main/java/net/Gabou/projectatmosphere/registry/ModParticles.java
@@ -1,8 +1,10 @@
 package net.Gabou.projectatmosphere.registry;
 
-import net.minecraft.core.registries.Registries;
+import com.mojang.serialization.Codec;
+import net.Gabou.projectatmosphere.particles.DebrisParticleData;
 import net.minecraft.core.particles.ParticleType;
 import net.minecraft.core.particles.SimpleParticleType;
+import net.minecraft.core.registries.Registries;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.RegistryObject;
@@ -34,6 +36,14 @@ public class ModParticles {
             PARTICLES.register("heart_orange", () -> new SimpleParticleType(true));
     public static final RegistryObject<SimpleParticleType> HEART_JAUNE =
             PARTICLES.register("heart_jaune", () -> new SimpleParticleType(true));
+
+    public static final RegistryObject<ParticleType<DebrisParticleData>> DEBRIS =
+            PARTICLES.register("debris", () -> new ParticleType<DebrisParticleData>(true, DebrisParticleData.DESERIALIZER) {
+                @Override
+                public Codec<DebrisParticleData> codec() {
+                    return DebrisParticleData.CODEC;
+                }
+            });
 
     public static void register(IEventBus bus) {
         PARTICLES.register(bus);


### PR DESCRIPTION
## Summary
- Add DebrisParticle and DebrisParticleData to render swirling debris around tornadoes
- Register new debris particle type and provider
- Spawn debris particles each tick so debris remains synced with moving tornadoes

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_6892a300e64c8331a7c051e763734e3a