### PR TITLE
Add weather radar item

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/items/WeatherRadarItem.java
+++ b/src/main/java/net/Gabou/projectatmosphere/items/WeatherRadarItem.java
@@ -1,0 +1,32 @@
+package net.Gabou.projectatmosphere.items;
+
+import net.Gabou.projectatmosphere.blocks.InstrumentReader;
+import net.Gabou.projectatmosphere.util.InstrumentUtils;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResultHolder;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+
+public class WeatherRadarItem extends Item implements InstrumentReader {
+    public WeatherRadarItem(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
+        if (!player.isShiftKeyDown()) {
+            if (level.isClientSide) {
+                display(level, player);
+            }
+            return InteractionResultHolder.success(player.getItemInHand(hand));
+        }
+        return super.use(level, player, hand);
+    }
+
+    @Override
+    public void display(Level level, Player player) {
+        InstrumentUtils.displayStorm(level, player);
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/registry/ModItems.java
+++ b/src/main/java/net/Gabou/projectatmosphere/registry/ModItems.java
@@ -28,6 +28,9 @@ public class ModItems {
     public static final RegistryObject<Item> HUMIDIMETER = ITEMS.register("humidimeter_block",
             () -> new Humidimeter(ModBlocks.HUMIDIMETER_BLOCK.get(), new Item.Properties()));
 
+    public static final RegistryObject<Item> WEATHER_RADAR = ITEMS.register("weather_radar",
+            () -> new WeatherRadarItem(new Item.Properties()));
+
 
 
     public static final RegistryObject<Item> WOOD_BALAI = ITEMS.register("balai_bois",

--- a/src/main/java/net/Gabou/projectatmosphere/util/InstrumentUtils.java
+++ b/src/main/java/net/Gabou/projectatmosphere/util/InstrumentUtils.java
@@ -57,4 +57,18 @@ public class InstrumentUtils {
         String msg = "Current pressure: " + String.format("%.1fhPa", pressure);
         HUDOverlayRenderer.showTemperatureOverlay(msg);
     }
+
+    public static void displayStorm(Level level, Player player) {
+        if (!level.isClientSide) return;
+
+        String msg;
+        if (level.isThundering()) {
+            msg = "Storm detected!";
+        } else if (level.isRaining()) {
+            msg = "Rain detected.";
+        } else {
+            msg = "Skies clear.";
+        }
+        HUDOverlayRenderer.showTemperatureOverlay(msg);
+    }
 }

--- a/src/main/resources/assets/projectatmosphere/lang/en_us.json
+++ b/src/main/resources/assets/projectatmosphere/lang/en_us.json
@@ -2,6 +2,7 @@
   "item.projectatmosphere.thermometer": "Thermometer",
   "item.projectatmosphere.barometer": "Barometer",
   "item.projectatmosphere.humidimeter": "Hygrometer",
+  "item.projectatmosphere.weather_radar": "Weather Radar",
   "item.projectatmosphere.balai_bois": "Wooden Broom",
   "item.projectatmosphere.balai_pierre": "Stone Broom",
   "item.projectatmosphere.balai_fer": "Iron Broom",

--- a/src/main/resources/assets/projectatmosphere/lang/fr_fr.json
+++ b/src/main/resources/assets/projectatmosphere/lang/fr_fr.json
@@ -2,6 +2,7 @@
   "item.projectatmosphere.thermometer": "Thermomètre",
   "item.projectatmosphere.barometer": "Baromètre",
   "item.projectatmosphere.humidimeter": "Hygromètre",
+  "item.projectatmosphere.weather_radar": "Radar météo",
   "item.projectatmosphere.balai_bois": "Balai en bois",
   "item.projectatmosphere.balai_pierre": "Balai en pierre",
   "item.projectatmosphere.balai_fer": "Balai en fer",

--- a/src/main/resources/assets/projectatmosphere/models/item/weather_radar.json
+++ b/src/main/resources/assets/projectatmosphere/models/item/weather_radar.json
@@ -1,0 +1,3 @@
+{
+  "parent": "minecraft:item/compass"
+}


### PR DESCRIPTION
## Summary
- add handheld weather radar that differentiates storms from clear skies
- expose storm info through InstrumentUtils for reuse and overlays

## Testing
- `gradle build` *(fails: Plugin [id: 'net.minecraftforge.gradle', version: '[6.0.16,6.2)'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68935c257d3483318ce7ea2805497e5a