### PR TITLE
feat: add simple weather radar map

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/client/screen/WeatherRadarScreen.java
+++ b/src/main/java/net/Gabou/projectatmosphere/client/screen/WeatherRadarScreen.java
@@ -1,0 +1,53 @@
+package net.Gabou.projectatmosphere.client.screen;
+
+import dev.nonamecrackers2.simpleclouds.common.cloud.region.CloudRegion;
+import dev.nonamecrackers2.simpleclouds.common.world.CloudManager;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+
+import java.util.List;
+
+public class WeatherRadarScreen extends Screen {
+    private static final int MAP_SIZE = 128;
+    private static final int RANGE = 2048;
+
+    private final Player player;
+    private final CloudManager<?> cloudManager;
+    private final float scale;
+
+    public WeatherRadarScreen(Player player) {
+        super(Component.translatable("item.projectatmosphere.weather_radar"));
+        this.player = player;
+        this.cloudManager = CloudManager.get(player.level());
+        this.scale = (float) RANGE / MAP_SIZE;
+    }
+
+    @Override
+    public boolean isPauseScreen() {
+        return false;
+    }
+
+    @Override
+    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        renderBackground(guiGraphics);
+        int left = (this.width - MAP_SIZE) / 2;
+        int top = (this.height - MAP_SIZE) / 2;
+        guiGraphics.fill(left, top, left + MAP_SIZE, top + MAP_SIZE, 0xFF000000);
+
+        if (cloudManager != null) {
+            List<CloudRegion> clouds = cloudManager.getClouds();
+            for (CloudRegion region : clouds) {
+                float dx = (region.getWorldX() - (float) player.getX()) / scale;
+                float dz = (region.getWorldZ() - (float) player.getZ()) / scale;
+                int r = Math.max(1, Math.round(region.getWorldRadius() / scale));
+                int x = left + MAP_SIZE / 2 + Math.round(dx);
+                int y = top + MAP_SIZE / 2 + Math.round(dz);
+                guiGraphics.fill(x - r, y - r, x + r, y + r, 0x80FFFFFF);
+            }
+        }
+
+        super.render(guiGraphics, mouseX, mouseY, partialTick);
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/items/WeatherRadarItem.java
+++ b/src/main/java/net/Gabou/projectatmosphere/items/WeatherRadarItem.java
@@ -1,7 +1,8 @@
 package net.Gabou.projectatmosphere.items;
 
 import net.Gabou.projectatmosphere.blocks.InstrumentReader;
-import net.Gabou.projectatmosphere.util.InstrumentUtils;
+import net.Gabou.projectatmosphere.client.screen.WeatherRadarScreen;
+import net.minecraft.client.Minecraft;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.player.Player;
@@ -27,6 +28,6 @@ public class WeatherRadarItem extends Item implements InstrumentReader {
 
     @Override
     public void display(Level level, Player player) {
-        InstrumentUtils.displayStorm(level, player);
+        Minecraft.getInstance().setScreen(new WeatherRadarScreen(player));
     }
 }


### PR DESCRIPTION
## Summary
- add client screen to render a basic 2D radar map of nearby clouds
- open radar screen when using the Weather Radar item

## Testing
- `gradle build` *(fails: Plugin [id: 'net.minecraftforge.gradle', version: '[6.0.16,6.2)'] was not found)*


------
https://chatgpt.com/codex/tasks/task_e_68935e8283bc8331b544b64f4dbeff34