### PR TITLE
Clean up tornado rendering and shader

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/client/ClientRenderHook.java
+++ b/src/main/java/net/Gabou/projectatmosphere/client/ClientRenderHook.java
@@ -1,27 +1,16 @@
 package net.Gabou.projectatmosphere.client;
 
-import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.*;
-import dev.nonamecrackers2.simpleclouds.client.renderer.SimpleCloudsRenderer;
-import dev.nonamecrackers2.simpleclouds.common.cloud.SimpleCloudsConstants;
-import dev.nonamecrackers2.simpleclouds.common.config.SimpleCloudsConfig;
+import com.mojang.blaze3d.vertex.PoseStack;
 import net.Gabou.projectatmosphere.ProjectAtmosphere;
-import net.Gabou.projectatmosphere.compat.SimpleCloudsCompat;
 import net.Gabou.projectatmosphere.modules.tornado.TornadoInstance;
 import net.Gabou.projectatmosphere.modules.tornado.TornadoManager;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.GameRenderer;
-import net.minecraft.client.renderer.ShaderInstance;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RenderLevelStageEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import org.joml.Matrix4f;
-import org.joml.Vector3f;
-import org.lwjgl.opengl.GL11;
 
 import java.util.List;
 
@@ -45,19 +34,10 @@ public class ClientRenderHook {
         List<TornadoInstance> tornadoes = TornadoManager.getActiveTornadoes();
         if (tornadoes.isEmpty()) return;
 
-        ShaderInstance shader = MyShaders.TORNADO;
-        if (shader == null) return;
-
-        RenderSystem.setShader(() -> shader);
-        RenderSystem.enableBlend();
-        RenderSystem.defaultBlendFunc();
-        RenderSystem.disableCull();
-
         poseStack.pushPose();
         poseStack.translate(-camPos.x, -camPos.y, -camPos.z);
 
         for (TornadoInstance tornado : tornadoes) {
-            poseStack.pushPose();
             TornadoRenderHandler.renderTornado(
                     poseStack,
                     tornado.position.x,
@@ -65,12 +45,9 @@ public class ClientRenderHook {
                     tornado.position.z,
                     tornado.getTwist()
             );
-            poseStack.popPose();
         }
 
         poseStack.popPose();
-        RenderSystem.disableBlend();
-        RenderSystem.enableCull();
     }
 
 

--- a/src/main/java/net/Gabou/projectatmosphere/client/TornadoRenderHandler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/client/TornadoRenderHandler.java
@@ -3,7 +3,6 @@ package net.Gabou.projectatmosphere.client;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import dev.nonamecrackers2.simpleclouds.common.config.SimpleCloudsConfig;
-import net.Gabou.projectatmosphere.client.render.TornadoMesh;
 import net.Gabou.projectatmosphere.modules.tornado.TornadoInstance;
 import net.Gabou.projectatmosphere.modules.tornado.TornadoManager;
 import net.Gabou.projectatmosphere.particles.DebrisParticleData;
@@ -173,6 +172,7 @@ public class TornadoRenderHandler {
     public static void renderTornado(PoseStack stack, double x, double y, double z, float twistSpeed) {
         ShaderInstance shader = MyShaders.TORNADO;
         if (shader == null) return;
+        RenderSystem.setShader(() -> shader);
 
         stack.pushPose();
         stack.translate(x, y, z);

--- a/src/main/resources/assets/projectatmosphere/shaders/core/tornado.fsh
+++ b/src/main/resources/assets/projectatmosphere/shaders/core/tornado.fsh
@@ -39,23 +39,6 @@ float noise(vec3 p) {
                mix(mix(n001, n101, u.x), mix(n011, n111, u.x), u.y), u.z);
 }
 
-// Compute the radius of the funnel at a given height (0..1)
-float funnelRadius(float y) {
-    float base = 0.40;  // radius at ground
-    float top = 0.05;   // radius near the top
-    return mix(base, top, y);
-}
-
-// Fade out the core so the tornado is hollow inside
-float coreMask(float r, float inner) {
-    return smoothstep(inner, inner - 0.02, r);
-}
-
-// Fade out towards the outside edge of the funnel
-float edgeMask(float r, float radius) {
-    return smoothstep(radius, radius - 0.03, r);
-}
-
 // Fade vertically so the funnel softens near top and bottom
 float verticalFade(float y) {
     float top = smoothstep(1.0, 0.7, y);
@@ -73,43 +56,24 @@ vec2 buildSwirlUV(float angle, float y, vec2 offset) {
 }
 
 void main() {
-    vec2 uv = texCoord;
-    // Translate to center-based coordinates (-0.5..0.5)
-    vec2 p = uv - 0.5;
-
-    float height = clamp(uv.y, 0.0, 1.0);
-    float baseRadius = funnelRadius(height);
-
-    float r = length(p);
-    float angle = atan(p.y, p.x);
-
-    // Determine masking to clip pixels outside the funnel
-    float outer = edgeMask(r, baseRadius);
-    float inner = coreMask(r, 0.02);
-    float mask = outer * inner * verticalFade(height);
-
-    if (mask <= 0.0) {
-        fragColor = vec4(0.0);
-        return;
-    }
+    float height = clamp(texCoord.y, 0.0, 1.0);
+    float angle = texCoord.x * 2.0 * PI;
 
     // Base rotation derived from time and height
     float rotation = Time * TwistSpeed + height * 12.0;
 
     // Low-frequency noise for large curls
-    vec2 polar = vec2(angle / (2.0 * PI), height);
+    vec2 polar = vec2(texCoord.x, height);
     float n1 = noise(vec3(polar * 3.0, Time * 0.05));
     float n2 = noise(vec3(polar * 6.0, -Time * 0.04));
 
     angle += rotation + n1 * 4.0;
-    r += (n2 - 0.5) * 0.05;
 
     // High-frequency noise for fine turbulent motion
     vec2 offset;
-    offset.x = noise(vec3(uv * 5.0, Time * 0.02));
-    offset.y = noise(vec3(uv.yx * 5.0, -Time * 0.02));
+    offset.x = noise(vec3(texCoord * 5.0, Time * 0.02));
+    offset.y = noise(vec3(texCoord.yx * 5.0, -Time * 0.02));
     angle += (offset.x - 0.5) * 3.0;
-    r += (offset.y - 0.5) * 0.03;
 
     // Build final UV for sampling the base texture
     vec2 swirlUV = buildSwirlUV(angle, height, offset);
@@ -119,7 +83,7 @@ void main() {
 
     vec3 color = base.rgb * (0.5 + n1 * 0.5);
 
-    float alpha = base.a * mask;
+    float alpha = base.a * verticalFade(height);
     alpha *= 0.7 + n2 * 0.3;
 
     fragColor = vec4(color, alpha);


### PR DESCRIPTION
## Summary
- Simplify client render hook to just position the camera and dispatch tornado rendering
- Centralize shader setup and texture binding in `TornadoRenderHandler`
- Rework tornado fragment shader to sample the funnel texture and drive swirl/alpha calculations on the GPU

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_6894442b40b483319cba3f4769673c9f