### PR TITLE
feat: add server tornado logic and natural spawning

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/event/EventHandler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/event/EventHandler.java
@@ -9,17 +9,20 @@ import net.Gabou.projectatmosphere.blocks.BlockManager;
 import net.Gabou.projectatmosphere.manager.AtmosphereManager;
 import net.Gabou.projectatmosphere.manager.SimpleCloudSpawner;
 import net.Gabou.projectatmosphere.modules.core.CloudLibrary;
-import net.Gabou.projectatmosphere.util.AsyncAtmosphereService;
+import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.Gabou.projectatmosphere.modules.tornado.TornadoManager;
+import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
+import net.Gabou.projectatmosphere.util.AtmosphereUtils;
+import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
-
-import static net.Gabou.projectatmosphere.ProjectAtmosphere.LOGGER;
 
 @Mod.EventBusSubscriber(modid = ProjectAtmosphere.MODID)
 public class EventHandler {
@@ -28,6 +31,9 @@ public class EventHandler {
     // Increase delay between tempest effects to reduce how often
     // cochonerie (debris) spawns
     private static final int MIN_TICKS_BETWEEN_TEMPESTA = 2000;
+
+    private static final int TICKS_BETWEEN_TORNADO_CHECK = 200;
+    private static final float NATURAL_TORNADO_CHANCE = 0.01f;
 
     private static int tickCounter = 0;
 
@@ -52,6 +58,7 @@ public class EventHandler {
         ServerCloudManager cloudManager = (ServerCloudManager) CloudManager.get(serverLevel);
         CloudGenerator generator = cloudManager.getCloudGenerator();
         AtmosphereManager.tick(serverLevel);
+        TornadoManager.tick(serverLevel);
         if (generator.getTicksTillNextGen() <= 0 && ticksSinceLastCloudSpawn % 1000 == 0) {
             SimpleCloudSpawner.trySpawnClouds(serverLevel, generator);
             ticksSinceLastCloudSpawn = 0;
@@ -74,6 +81,18 @@ public class EventHandler {
             }
 
 
+        }
+
+        if (tickCounter % TICKS_BETWEEN_TORNADO_CHECK == 0) {
+            for (CloudRegion region : generator.getClouds()) {
+                int severity = CloudLibrary.getSeverityFromRessourceLocation(region.getCloudTypeId());
+                if (severity >= 6 && serverLevel.random.nextFloat() < NATURAL_TORNADO_CHANCE) {
+                    BlockPos spawnPos = new BlockPos((int) region.getPosX(), serverLevel.getSeaLevel(), (int) region.getPosZ());
+                    BiomeInstanceKey key = AtmosphereUtils.getBiomeKey(serverLevel, spawnPos);
+                    WindVector wind = ForecastOrchestrator.getCurrentWind(key, serverLevel.getGameTime());
+                    TornadoManager.spawnServer(serverLevel, new Vec3(spawnPos.getX(), spawnPos.getY(), spawnPos.getZ()), 4.0f, wind);
+                }
+            }
         }
         ticksSinceLastCloudSpawn++;
         tickCounter++;

--- a/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoCommand.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoCommand.java
@@ -1,6 +1,5 @@
 package net.Gabou.projectatmosphere.modules.tornado;
 
-import net.Gabou.projectatmosphere.compat.SimpleCloudsCompat;
 import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
 import net.Gabou.projectatmosphere.util.AtmosphereUtils;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
@@ -13,9 +12,6 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.network.PacketDistributor;
-import net.Gabou.projectatmosphere.network.NetworkHandler;
-import net.Gabou.projectatmosphere.network.SpawnTornadoPacket;
 
 @Mod.EventBusSubscriber
 public class TornadoCommand {
@@ -35,10 +31,10 @@ public class TornadoCommand {
                    //SimpleCloudsCompat.spawnCloudInBiome("cumulonimbus", key, level, null, wind);
 
                     Vec3 playerPos = player.position();
-                    // Spawn tornado visually and sync with clients
-                    TornadoManager.spawn(new Vec3(playerPos.x,level.getSeaLevel(),playerPos.z), 2.5f, wind);
-                    NetworkHandler.CHANNEL.send(PacketDistributor.ALL.noArg(),
-                            new SpawnTornadoPacket(player.position(), 2.5f, wind));
+                    TornadoManager.spawnServer(level,
+                            new Vec3(playerPos.x, level.getSeaLevel(), playerPos.z),
+                            2.5f,
+                            wind);
 
                     ctx.getSource().sendSuccess(
                             () -> Component.literal("🌪️ Tornado + ☁️ Cumulonimbus spawned."), true);

--- a/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoInstance.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoInstance.java
@@ -1,9 +1,15 @@
 package net.Gabou.projectatmosphere.modules.tornado;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.BlockParticleOption;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 
 import net.Gabou.projectatmosphere.modules.core.WindVector;
@@ -42,18 +48,35 @@ public class TornadoInstance {
     }
 
     /**
-     * Called each tick from tornado manager to handle sound & destruction
+     * Called each tick from tornado manager. Server handles demolition,
+     * client relies on separate rendering logic.
      */
     public void tick(Level level) {
-        long now = System.currentTimeMillis();
+        if (level.isClientSide) {
+            return;
+        }
 
+        long now = System.currentTimeMillis();
         if (now - lastDemolitionCheck >= demolitionIntervalMs) {
             lastDemolitionCheck = now;
-
-            // Sound effect
             playDemolitionSound(level);
+            demolishBlocks((ServerLevel) level);
+        }
+    }
 
-            // Future: Add block destruction, particles, debris here
+    private void demolishBlocks(ServerLevel level) {
+        BlockPos center = BlockPos.containing(position);
+        int intRadius = Mth.ceil(radius);
+        for (BlockPos pos : BlockPos.betweenClosed(
+                center.offset(-intRadius, -1, -intRadius),
+                center.offset(intRadius, intRadius, intRadius))) {
+            BlockState state = level.getBlockState(pos);
+            if (state.is(BlockTags.LEAVES) || state.is(BlockTags.LOGS)) {
+                level.destroyBlock(pos, false);
+                level.sendParticles(new BlockParticleOption(ParticleTypes.BLOCK, state),
+                        pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5,
+                        5, 0.2, 0.2, 0.2, 0.05);
+            }
         }
     }
 

--- a/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoManager.java
@@ -1,8 +1,12 @@
 package net.Gabou.projectatmosphere.modules.tornado;
 
 import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.Gabou.projectatmosphere.network.NetworkHandler;
+import net.Gabou.projectatmosphere.network.SpawnTornadoPacket;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.network.PacketDistributor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +23,11 @@ public class TornadoManager {
         spawn(pos, radius, WindVector.fromBase(0, 0));
     }
 
+    public static void spawnServer(ServerLevel level, Vec3 pos, float radius, WindVector wind) {
+        spawn(pos, radius, wind);
+        NetworkHandler.CHANNEL.send(PacketDistributor.ALL.noArg(), new SpawnTornadoPacket(pos, radius, wind));
+    }
+
     public static List<TornadoInstance> getActiveTornadoes() {
         return ACTIVE_TORNADOES;
     }
@@ -28,7 +37,6 @@ public class TornadoManager {
     }
 
     public static void tick(Level level) {
-        // Remove tornados after 20 seconds
         ACTIVE_TORNADOES.removeIf(tornado -> tornado.getLifetimeSeconds() > 600);
         for (TornadoInstance tornado : ACTIVE_TORNADOES) {
             float speed = tornado.wind.baseSpeed() * 0.05f;
@@ -38,7 +46,9 @@ public class TornadoManager {
                     Math.sin(tornado.wind.angleRadians()) * speed);
             tornado.tick(level);
         }
-        shaderTime += 0.05f;
+        if (level.isClientSide) {
+            shaderTime += 0.05f;
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- Split tornado logic into server control and client rendering
- Server breaks wood and leaf blocks around tornadoes with particle effects
- Introduce natural tornado spawning beneath severe clouds with network sync

## Testing
- `gradle build` *(fails: Plugin [id: 'net.minecraftforge.gradle', version: '[6.0.16,6.2)'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689543eff140833198c2d2929c81f9b6