### PR TITLE
Add tornado glass damage and auto-repair option

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/config/AtmoCommonConfig.java
+++ b/src/main/java/net/Gabou/projectatmosphere/config/AtmoCommonConfig.java
@@ -37,7 +37,7 @@ public class AtmoCommonConfig {
                 .comment("Maximum number of storm debris items allowed per chunk")
                 .defineInRange("maxStormDebrisPerChunk", 30, 0, Integer.MAX_VALUE);
         AUTO_REPAIR_GLASS = builder
-                .comment("Automatically repair tornado-damaged glass after 5 minutes if undamaged")
+                .comment("Automatically repair tornado-damaged glass after 5 minutes of no new damage")
                 .define("autoRepairGlass", true);
         builder.pop();
         COMMON_SPEC = builder.build();

--- a/src/main/java/net/Gabou/projectatmosphere/config/AtmoCommonConfig.java
+++ b/src/main/java/net/Gabou/projectatmosphere/config/AtmoCommonConfig.java
@@ -20,6 +20,7 @@ public class AtmoCommonConfig {
     public static final ForgeConfigSpec.BooleanValue FORCE_SHARED_EXECUTOR;
     public static final ForgeConfigSpec.BooleanValue ENABLE_STORM_DEBRIS;
     public static final ForgeConfigSpec.IntValue MAX_STORM_DEBRIS_PER_CHUNK;
+    public static final ForgeConfigSpec.BooleanValue AUTO_REPAIR_GLASS;
 
     static {
         ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
@@ -35,6 +36,9 @@ public class AtmoCommonConfig {
         MAX_STORM_DEBRIS_PER_CHUNK = builder
                 .comment("Maximum number of storm debris items allowed per chunk")
                 .defineInRange("maxStormDebrisPerChunk", 30, 0, Integer.MAX_VALUE);
+        AUTO_REPAIR_GLASS = builder
+                .comment("Automatically repair tornado-damaged glass after 5 minutes if undamaged")
+                .define("autoRepairGlass", true);
         builder.pop();
         COMMON_SPEC = builder.build();
     }

--- a/src/main/java/net/Gabou/projectatmosphere/event/EventHandler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/event/EventHandler.java
@@ -11,6 +11,7 @@ import net.Gabou.projectatmosphere.manager.SimpleCloudSpawner;
 import net.Gabou.projectatmosphere.modules.core.CloudLibrary;
 import net.Gabou.projectatmosphere.modules.core.WindVector;
 import net.Gabou.projectatmosphere.modules.tornado.TornadoManager;
+import net.Gabou.projectatmosphere.modules.tornado.GlassDamageManager;
 import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
 import net.Gabou.projectatmosphere.util.AtmosphereUtils;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
@@ -59,6 +60,7 @@ public class EventHandler {
         CloudGenerator generator = cloudManager.getCloudGenerator();
         AtmosphereManager.tick(serverLevel);
         TornadoManager.tick(serverLevel);
+        GlassDamageManager.tick(serverLevel);
         if (generator.getTicksTillNextGen() <= 0 && ticksSinceLastCloudSpawn % 1000 == 0) {
             SimpleCloudSpawner.trySpawnClouds(serverLevel, generator);
             ticksSinceLastCloudSpawn = 0;

--- a/src/main/java/net/Gabou/projectatmosphere/modules/tornado/GlassDamageManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/tornado/GlassDamageManager.java
@@ -16,8 +16,6 @@ public class GlassDamageManager {
 
     private static final Map<BlockPos, GlassState> GLASS_STATE = new HashMap<>();
     private static final int MAX_DAMAGE = 3;
-    private static final long REPAIR_DELAY_MS = 5 * 60 * 1000L; // 5 minutes
-
     public static void damageGlass(ServerLevel level, BlockPos pos, BlockState state) {
         GlassState glass = GLASS_STATE.computeIfAbsent(pos.immutable(), p -> new GlassState(state));
         glass.damage++;

--- a/src/main/java/net/Gabou/projectatmosphere/modules/tornado/GlassDamageManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/tornado/GlassDamageManager.java
@@ -1,0 +1,56 @@
+package net.Gabou.projectatmosphere.modules.tornado;
+
+import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Tracks damage done to glass blocks by tornado debris and handles auto repair.
+ */
+public class GlassDamageManager {
+
+    private static final Map<BlockPos, GlassState> GLASS_STATE = new HashMap<>();
+    private static final int MAX_DAMAGE = 3;
+    private static final long REPAIR_DELAY_MS = 5 * 60 * 1000L; // 5 minutes
+
+    public static void damageGlass(ServerLevel level, BlockPos pos, BlockState state) {
+        GlassState glass = GLASS_STATE.computeIfAbsent(pos.immutable(), p -> new GlassState(state));
+        glass.damage++;
+        glass.lastDamageTime = System.currentTimeMillis();
+        if (glass.damage >= MAX_DAMAGE) {
+            level.destroyBlock(pos, false);
+            glass.broken = true;
+        }
+    }
+
+    public static void tick(ServerLevel level) {
+        long now = System.currentTimeMillis();
+        Iterator<Map.Entry<BlockPos, GlassState>> iterator = GLASS_STATE.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<BlockPos, GlassState> entry = iterator.next();
+            GlassState state = entry.getValue();
+            if (now - state.lastDamageTime >= REPAIR_DELAY_MS) {
+                if (state.broken && AtmoCommonConfig.AUTO_REPAIR_GLASS.get()) {
+                    level.setBlock(entry.getKey(), state.originalState, 3);
+                }
+                iterator.remove();
+            }
+        }
+    }
+
+    private static class GlassState {
+        final BlockState originalState;
+        int damage = 0;
+        boolean broken = false;
+        long lastDamageTime = System.currentTimeMillis();
+
+        GlassState(BlockState originalState) {
+            this.originalState = originalState;
+        }
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoInstance.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoInstance.java
@@ -10,9 +10,15 @@ import net.minecraft.tags.BlockTags;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.GlassBlock;
+import net.minecraft.world.level.block.GlassPaneBlock;
+import net.minecraft.world.level.block.StainedGlassBlock;
+import net.minecraft.world.level.block.StainedGlassPaneBlock;
+import net.minecraft.world.level.block.TintedGlassBlock;
 import net.minecraft.world.phys.Vec3;
 
 import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.Gabou.projectatmosphere.modules.tornado.GlassDamageManager;
 
 public class TornadoInstance {
 
@@ -68,16 +74,31 @@ public class TornadoInstance {
         BlockPos center = BlockPos.containing(position);
         int intRadius = Mth.ceil(radius);
         for (BlockPos pos : BlockPos.betweenClosed(
-                center.offset(-intRadius, -1, -intRadius),
-                center.offset(intRadius, intRadius, intRadius))) {
+                center.offset(-intRadius - 5, -1, -intRadius - 5),
+                center.offset(intRadius + 5, intRadius, intRadius + 5))) {
             BlockState state = level.getBlockState(pos);
+            double distSq = pos.distSqr(center);
             if (state.is(BlockTags.LEAVES) || state.is(BlockTags.LOGS)) {
                 level.destroyBlock(pos, false);
                 level.sendParticles(new BlockParticleOption(ParticleTypes.BLOCK, state),
                         pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5,
                         5, 0.2, 0.2, 0.2, 0.05);
+            } else if (isGlass(state)) {
+                if (distSq <= radius * radius) {
+                    level.destroyBlock(pos, false);
+                } else if (distSq <= (radius + 5) * (radius + 5)) {
+                    GlassDamageManager.damageGlass(level, pos, state);
+                }
             }
         }
+    }
+
+    private boolean isGlass(BlockState state) {
+        return state.getBlock() instanceof GlassBlock
+                || state.getBlock() instanceof GlassPaneBlock
+                || state.getBlock() instanceof StainedGlassBlock
+                || state.getBlock() instanceof StainedGlassPaneBlock
+                || state.getBlock() instanceof TintedGlassBlock;
     }
 
     private void playDemolitionSound(Level level) {

--- a/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoInstance.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoInstance.java
@@ -74,8 +74,8 @@ public class TornadoInstance {
         BlockPos center = BlockPos.containing(position);
         int intRadius = Mth.ceil(radius);
         for (BlockPos pos : BlockPos.betweenClosed(
-                center.offset(-intRadius - 5, -1, -intRadius - 5),
-                center.offset(intRadius + 5, intRadius, intRadius + 5))) {
+                center.offset(-intRadius - DEBRIS_RANGE_EXTENSION, -1, -intRadius - DEBRIS_RANGE_EXTENSION),
+                center.offset(intRadius + DEBRIS_RANGE_EXTENSION, intRadius, intRadius + DEBRIS_RANGE_EXTENSION))) {
             BlockState state = level.getBlockState(pos);
             double distSq = pos.distSqr(center);
             if (state.is(BlockTags.LEAVES) || state.is(BlockTags.LOGS)) {


### PR DESCRIPTION
## Summary
- Track and repair tornado-damaged glass blocks
- Destroy glass hit directly by tornadoes and damage nearby panes via debris
- Add config for optional automatic glass repair

## Testing
- `gradle build` *(fails: Plugin [id: 'net.minecraftforge.gradle', version: '[6.0.16,6.2)'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68975d260f908331bcce9c819d56b12f