### PR TITLE
docs: add Javadoc to commands and items

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/command/DebugAtmoCommand.java
+++ b/src/main/java/net/Gabou/projectatmosphere/command/DebugAtmoCommand.java
@@ -19,6 +19,14 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 
 public class DebugAtmoCommand {
+    /**
+     * Sends a formatted forecast message to the command source for the given biome.
+     *
+     * @param ctx       the command context
+     * @param forecast  the forecast to display, may be {@code null}
+     * @param biome     the biome to describe
+     * @return {@code 1} if a forecast was sent, {@code 0} otherwise
+     */
     private static int sendForecast(CommandContext<CommandSourceStack> ctx, BiomeForecast forecast, ResourceLocation biome) {
         if (forecast == null) {
             ctx.getSource().sendFailure(Component.literal("No forecast found for biome: " + biome));
@@ -34,6 +42,12 @@ public class DebugAtmoCommand {
                 ), false);
         return 1;
     }
+    /**
+     * Registers the <code>/weatherdebug</code> command and its subcommands used for debugging
+     * atmospheric data.
+     *
+     * @param dispatcher the command dispatcher used to register the command
+     */
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
         dispatcher.register(
                 Commands.literal("weatherdebug")
@@ -101,6 +115,12 @@ public class DebugAtmoCommand {
         );
     }
 
+    /**
+     * Formats a two-element float array to a comma-separated string with one decimal place.
+     *
+     * @param arr the array to format
+     * @return the formatted string
+     */
     private static String format(float[] arr) {
         return String.format("%.1f, %.1f", arr[0], arr[1]);
     }

--- a/src/main/java/net/Gabou/projectatmosphere/command/SpawnCloudCommand.java
+++ b/src/main/java/net/Gabou/projectatmosphere/command/SpawnCloudCommand.java
@@ -10,6 +10,12 @@ import net.minecraft.world.level.Level;
 import java.util.Objects;
 
 public class SpawnCloudCommand {
+    /**
+     * Registers the <code>/spawncloud</code> command which spawns a cloud for the executing player
+     * when used in the Overworld.
+     *
+     * @param dispatcher the command dispatcher used to register the command
+     */
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
         dispatcher.register(Commands.literal("spawncloud")
                 .requires(source -> source.hasPermission(2))

--- a/src/main/java/net/Gabou/projectatmosphere/items/Anemometer.java
+++ b/src/main/java/net/Gabou/projectatmosphere/items/Anemometer.java
@@ -6,10 +6,22 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 
 public class Anemometer extends InstrumentBlockItem {
+    /**
+     * Creates a new anemometer item.
+     *
+     * @param block      the block associated with this item
+     * @param properties the item properties
+     */
     public Anemometer(Block block, Properties properties) {
         super(block, properties);
     }
 
+    /**
+     * Displays the current wind speed to the player.
+     *
+     * @param level  the world in which the player resides
+     * @param player the player using the item
+     */
     @Override
     public void display(Level level, Player player) {
         InstrumentUtils.displayWind(level, player);

--- a/src/main/java/net/Gabou/projectatmosphere/items/Balai.java
+++ b/src/main/java/net/Gabou/projectatmosphere/items/Balai.java
@@ -20,9 +20,25 @@ import net.minecraft.world.level.block.state.BlockState;
 
 public class Balai extends DiggerItem {
 
+    /**
+     * Creates a new broom item capable of sweeping dust layers.
+     *
+     * @param p_204108_ attack damage modifier
+     * @param p_204109_ attack speed modifier
+     * @param p_204110_ tool tier
+     * @param p_204111_ effective block tag
+     * @param p_204112_ item properties
+     */
     public Balai(float p_204108_, float p_204109_, Tier p_204110_, TagKey<Block> p_204111_, Properties p_204112_) {
         super(p_204108_, p_204109_, p_204110_, p_204111_, p_204112_);
     }
+
+    /**
+     * Removes a dust layer at the targeted position and plays a sweeping animation.
+     *
+     * @param context the use-on context
+     * @return the interaction result
+     */
     @Override
     public InteractionResult useOn(UseOnContext context) {
         Level level = context.getLevel();

--- a/src/main/java/net/Gabou/projectatmosphere/items/Barometre.java
+++ b/src/main/java/net/Gabou/projectatmosphere/items/Barometre.java
@@ -6,10 +6,22 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 
 public class Barometre extends InstrumentBlockItem {
+    /**
+     * Creates a new barometer item.
+     *
+     * @param block      the block associated with this item
+     * @param properties the item properties
+     */
     public Barometre(Block block, Properties properties) {
         super(block, properties);
     }
 
+    /**
+     * Displays the current atmospheric pressure to the player.
+     *
+     * @param level  the world in which the player resides
+     * @param player the player using the item
+     */
     @Override
     public void display(Level level, Player player) {
         InstrumentUtils.displayPressure(level, player);

--- a/src/main/java/net/Gabou/projectatmosphere/items/Humidimeter.java
+++ b/src/main/java/net/Gabou/projectatmosphere/items/Humidimeter.java
@@ -7,10 +7,22 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 
 public class Humidimeter extends InstrumentBlockItem {
+    /**
+     * Creates a new humidimeter item.
+     *
+     * @param block      the block associated with this item
+     * @param properties the item properties
+     */
     public Humidimeter(Block block, Properties properties) {
         super(block, properties);
     }
 
+    /**
+     * Displays the current humidity level to the player.
+     *
+     * @param level  the world in which the player resides
+     * @param player the player using the item
+     */
     @Override
     public void display(Level level, Player player) {
         InstrumentUtils.displayHumidity(level, player);

--- a/src/main/java/net/Gabou/projectatmosphere/items/InstrumentBlockItem.java
+++ b/src/main/java/net/Gabou/projectatmosphere/items/InstrumentBlockItem.java
@@ -12,16 +12,28 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 
 public abstract class InstrumentBlockItem extends BlockItem implements InstrumentReader {
+    /**
+     * Creates a new instrument item.
+     *
+     * @param block      the block associated with this item
+     * @param properties the item properties
+     */
     public InstrumentBlockItem(Block block, Properties properties) {
         super(block, properties);
     }
 
+    /**
+     * Uses the item on a block, displaying the instrument reading when the player is not sneaking.
+     *
+     * @param context the use-on context
+     * @return the interaction result
+     */
     @Override
     public InteractionResult useOn(UseOnContext context) {
         Player player = context.getPlayer();
         if (player != null && !player.isShiftKeyDown()) {
             if (context.getLevel().isClientSide) {
-                display(context.getLevel(), player); 
+                display(context.getLevel(), player);
             }
             return InteractionResult.SUCCESS;
         }
@@ -30,9 +42,17 @@ public abstract class InstrumentBlockItem extends BlockItem implements Instrumen
     }
 
 
+    /**
+     * Handles right-click interactions, displaying the instrument reading when the player is not sneaking.
+     *
+     * @param level  the world in which the item is used
+     * @param player the player using the item
+     * @param hand   the hand holding the item
+     * @return the interaction result holder
+     */
     @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
-        
+
         if (!player.isShiftKeyDown()) {
             if (level.isClientSide) {
                 display(level, player);

--- a/src/main/java/net/Gabou/projectatmosphere/items/Thermometre.java
+++ b/src/main/java/net/Gabou/projectatmosphere/items/Thermometre.java
@@ -6,10 +6,22 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 
 public class Thermometre extends InstrumentBlockItem {
+    /**
+     * Creates a new thermometer item.
+     *
+     * @param block      the block associated with this item
+     * @param properties the item properties
+     */
     public Thermometre(Block block, Properties properties) {
         super(block, properties);
     }
 
+    /**
+     * Displays the current temperature to the player.
+     *
+     * @param level  the world in which the player resides
+     * @param player the player using the item
+     */
     @Override
     public void display(Level level, Player player) {
         InstrumentUtils.displayTemperature(level, player);

--- a/src/main/java/net/Gabou/projectatmosphere/items/WeatherRadarItem.java
+++ b/src/main/java/net/Gabou/projectatmosphere/items/WeatherRadarItem.java
@@ -11,10 +11,23 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 public class WeatherRadarItem extends Item implements InstrumentReader {
+    /**
+     * Creates a new weather radar item.
+     *
+     * @param properties the item properties
+     */
     public WeatherRadarItem(Properties properties) {
         super(properties);
     }
 
+    /**
+     * Opens the weather radar interface when the player right-clicks without sneaking.
+     *
+     * @param level  the world in which the item is used
+     * @param player the player using the item
+     * @param hand   the hand holding the item
+     * @return the interaction result holder
+     */
     @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
         if (!player.isShiftKeyDown()) {
@@ -26,6 +39,12 @@ public class WeatherRadarItem extends Item implements InstrumentReader {
         return super.use(level, player, hand);
     }
 
+    /**
+     * Displays the weather radar screen to the player.
+     *
+     * @param level  the world in which the player resides
+     * @param player the player using the item
+     */
     @Override
     public void display(Level level, Player player) {
         Minecraft.getInstance().setScreen(new WeatherRadarScreen(player));


### PR DESCRIPTION
## Summary
- document spawncloud and weatherdebug commands
- add Javadoc for instrument items and weather radar
- describe broom interaction with dust layers

## Testing
- `gradle build` *(fails: cannot find symbol GlassPaneBlock in TornadoInstance.java)*

------
https://chatgpt.com/codex/tasks/task_e_6898c43f1c80833191fde23f8845f129