### PR TITLE
docs: add javadoc to block classes

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/blocks/AnemometerBlock.java
+++ b/src/main/java/net/Gabou/projectatmosphere/blocks/AnemometerBlock.java
@@ -5,11 +5,26 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
 
+/**
+ * Block representing an anemometer that reports wind speed.
+ */
 public class AnemometerBlock extends InstrumentBlock {
+
+    /**
+     * Creates a new anemometer block.
+     *
+     * @param properties block properties
+     */
     public AnemometerBlock(Properties properties) {
         super(properties);
     }
 
+    /**
+     * Displays the current wind information to the player.
+     *
+     * @param level  world level
+     * @param player player receiving the data
+     */
     @Override
     public void display(Level level, Player player) {
         InstrumentUtils.displayWind(level, player);

--- a/src/main/java/net/Gabou/projectatmosphere/blocks/BarometreBlock.java
+++ b/src/main/java/net/Gabou/projectatmosphere/blocks/BarometreBlock.java
@@ -4,11 +4,26 @@ import net.Gabou.projectatmosphere.util.InstrumentUtils;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 
+/**
+ * Block representing a barometer that shows atmospheric pressure.
+ */
 public class BarometreBlock extends InstrumentBlock {
+
+    /**
+     * Creates a new barometer block.
+     *
+     * @param properties block properties
+     */
     public BarometreBlock(Properties properties) {
         super(properties);
     }
 
+    /**
+     * Displays the current atmospheric pressure to the player.
+     *
+     * @param level  world level
+     * @param player player receiving the data
+     */
     @Override
     public void display(Level level, Player player) {
         InstrumentUtils.displayPressure(level, player);

--- a/src/main/java/net/Gabou/projectatmosphere/blocks/DustLayerBlock.java
+++ b/src/main/java/net/Gabou/projectatmosphere/blocks/DustLayerBlock.java
@@ -21,20 +21,46 @@ import java.util.List;
 public class DustLayerBlock extends SnowLayerBlock {
     public static final IntegerProperty LAYERS = IntegerProperty.create("layers", 1, 8);
 
+    /**
+     * Creates a dust layer block with a single layer by default.
+     *
+     * @param properties block properties
+     */
     public DustLayerBlock(Properties properties) {
         super(properties);
         this.registerDefaultState(this.stateDefinition.any().setValue(LAYERS, 1));
     }
 
+    /**
+     * Adds the layer property to the block state definition.
+     *
+     * @param builder builder used to define block states
+     */
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
         builder.add(LAYERS);
     }
 
+    /**
+     * Dust layers never form a full collision block, allowing entities to pass through.
+     *
+     * @param state block state
+     * @param getter world accessor
+     * @param pos block position
+     * @return false because dust layers are non-solid
+     */
     @Override
     public boolean isCollisionShapeFullBlock(BlockState state, BlockGetter getter, BlockPos pos) {
         return false;
     }
+
+    /**
+     * Determines the items dropped when the block is harvested.
+     *
+     * @param state   block state
+     * @param builder loot parameter builder
+     * @return list of item stacks dropped
+     */
     @Override
     public @NotNull List<ItemStack> getDrops(BlockState state, LootParams.Builder builder) {
         ItemStack tool = builder.getParameter(LootContextParams.TOOL);
@@ -44,7 +70,7 @@ public class DustLayerBlock extends SnowLayerBlock {
             return Collections.singletonList(new ItemStack(ModItems.DUST.get(), layers));
         }
 
-        
+
         return Collections.emptyList();
     }
 

--- a/src/main/java/net/Gabou/projectatmosphere/blocks/HumidimeterBlock.java
+++ b/src/main/java/net/Gabou/projectatmosphere/blocks/HumidimeterBlock.java
@@ -5,11 +5,26 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
 
+/**
+ * Block representing a humidimeter that reports relative humidity.
+ */
 public class HumidimeterBlock extends InstrumentBlock {
+
+    /**
+     * Creates a new humidimeter block.
+     *
+     * @param properties block properties
+     */
     public HumidimeterBlock(Properties properties) {
         super(properties);
     }
 
+    /**
+     * Displays humidity information to the player.
+     *
+     * @param level  world level
+     * @param player player receiving the data
+     */
     @Override
     public void display(Level level, Player player) {
         InstrumentUtils.displayHumidity(level, player);

--- a/src/main/java/net/Gabou/projectatmosphere/blocks/InstrumentBlock.java
+++ b/src/main/java/net/Gabou/projectatmosphere/blocks/InstrumentBlock.java
@@ -13,26 +13,57 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.phys.BlockHitResult;
 
+/**
+ * Base class for interactive weather instruments that display data when used.
+ */
 public abstract class InstrumentBlock extends HorizontalDirectionalBlock implements InstrumentReader {
+
+    /**
+     * Creates a new instrument block with a default north-facing orientation.
+     *
+     * @param properties block properties
+     */
     public InstrumentBlock(Properties properties) {
         super(properties);
         this.registerDefaultState(this.stateDefinition.any().setValue(FACING, Direction.NORTH));
     }
 
+    /**
+     * Adds the facing property to the block state definition.
+     *
+     * @param builder state definition builder
+     */
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
         builder.add(FACING);
     }
 
+    /**
+     * Determines the block's orientation when placed by a player.
+     *
+     * @param context placement context
+     * @return block state with facing opposite the player's direction
+     */
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
         return this.defaultBlockState().setValue(FACING, context.getHorizontalDirection().getOpposite());
     }
 
+    /**
+     * Handles player interaction by displaying instrument data.
+     *
+     * @param state  block state
+     * @param level  world level
+     * @param pos    block position
+     * @param player interacting player
+     * @param hand   hand used
+     * @param hit    hit result
+     * @return interaction result
+     */
     @Override
     public InteractionResult use(BlockState state, Level level, BlockPos pos,
                                  Player player, InteractionHand hand, BlockHitResult hit) {
-        display(level,player);
+        display(level, player);
         return  InteractionResult.SUCCESS;
     }
 

--- a/src/main/java/net/Gabou/projectatmosphere/blocks/InstrumentReader.java
+++ b/src/main/java/net/Gabou/projectatmosphere/blocks/InstrumentReader.java
@@ -3,6 +3,16 @@ package net.Gabou.projectatmosphere.blocks;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 
+/**
+ * Represents a block capable of displaying information to a player.
+ */
 public interface InstrumentReader {
+
+    /**
+     * Displays the instrument's data to the specified player.
+     *
+     * @param level  world level
+     * @param player player to receive the data
+     */
     void display(Level level, Player player);
 }

--- a/src/main/java/net/Gabou/projectatmosphere/blocks/ThermometerBlock.java
+++ b/src/main/java/net/Gabou/projectatmosphere/blocks/ThermometerBlock.java
@@ -4,11 +4,26 @@ import net.Gabou.projectatmosphere.util.InstrumentUtils;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 
+/**
+ * Block representing a thermometer that reports temperature.
+ */
 public class ThermometerBlock extends InstrumentBlock {
+
+    /**
+     * Creates a new thermometer block.
+     *
+     * @param properties block properties
+     */
     public ThermometerBlock(Properties properties) {
         super(properties);
     }
 
+    /**
+     * Displays temperature information to the player.
+     *
+     * @param level  world level
+     * @param player player receiving the data
+     */
     @Override
     public void display(Level level, Player player) {
         InstrumentUtils.displayTemperature(level, player);

--- a/src/main/java/net/Gabou/projectatmosphere/blocks/WeatherVaneBlock.java
+++ b/src/main/java/net/Gabou/projectatmosphere/blocks/WeatherVaneBlock.java
@@ -14,11 +14,29 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 
+/**
+ * Block representing a weather vane that aligns with the wind direction.
+ */
 public class WeatherVaneBlock extends InstrumentBlock {
+
+    /**
+     * Creates a new weather vane block.
+     *
+     * @param properties block properties
+     */
     public WeatherVaneBlock(BlockBehaviour.Properties properties) {
         super(properties);
     }
 
+    /**
+     * Schedules the first tick to update the vane orientation when placed.
+     *
+     * @param state     block state
+     * @param level     world level
+     * @param pos       block position
+     * @param oldState  previous block state
+     * @param isMoving  whether the block is moving
+     */
     @Override
     public void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean isMoving) {
         super.onPlace(state, level, pos, oldState, isMoving);
@@ -27,6 +45,14 @@ public class WeatherVaneBlock extends InstrumentBlock {
         }
     }
 
+    /**
+     * Periodically aligns the vane with the current wind direction.
+     *
+     * @param state  block state
+     * @param level  server level
+     * @param pos    block position
+     * @param random random source
+     */
     @Override
     public void tick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
         BiomeInstanceKey key = new BiomeInstanceKey(AtmosphereUtils.getBiomeLocation(pos, level), pos);
@@ -38,6 +64,12 @@ public class WeatherVaneBlock extends InstrumentBlock {
         level.scheduleTick(pos, this, 20);
     }
 
+    /**
+     * Displays the current wind information to the player.
+     *
+     * @param level  world level
+     * @param player player receiving the data
+     */
     @Override
     public void display(Level level, Player player) {
         InstrumentUtils.displayWind(level, player);


### PR DESCRIPTION
## Summary
- document DustLayerBlock methods with detailed parameter and return descriptions
- add Javadoc to instrument blocks and their implementations to explain behavior

## Testing
- `gradle build` *(fails: cannot find symbol GlassPaneBlock)*

------
https://chatgpt.com/codex/tasks/task_e_68992c4556808331bcd8e258d1b7bfe4