### PR TITLE
Add in-game config menu

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/ProjectAtmosphere.java
+++ b/src/main/java/net/Gabou/projectatmosphere/ProjectAtmosphere.java
@@ -10,6 +10,7 @@ import net.Gabou.projectatmosphere.particles.DebrisParticle;
 import net.Gabou.projectatmosphere.registry.*;
 import net.Gabou.projectatmosphere.manager.AtmosphereManager;
 import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
+import net.Gabou.projectatmosphere.config.AtmoConfigScreen;
 import net.Gabou.projectatmosphere.util.AsyncAtmosphereService;
 import net.Gabou.projectatmosphere.util.TickCounter;
 import net.minecraft.client.renderer.texture.TextureAtlas;
@@ -25,6 +26,7 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.client.ConfigScreenHandler;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.config.ModConfigEvent;
@@ -61,6 +63,8 @@ public class ProjectAtmosphere {
         IEventBus modEventBus = context.getModEventBus();
 
         context.registerConfig(ModConfig.Type.COMMON, AtmoCommonConfig.COMMON_SPEC);
+        context.registerExtensionPoint(ConfigScreenHandler.ConfigScreenFactory.class,
+                () -> new ConfigScreenHandler.ConfigScreenFactory((mc, screen) -> new AtmoConfigScreen(screen)));
 
         CompatHandler.init();
         ModItems.register(modEventBus);

--- a/src/main/java/net/Gabou/projectatmosphere/config/AtmoConfigScreen.java
+++ b/src/main/java/net/Gabou/projectatmosphere/config/AtmoConfigScreen.java
@@ -88,7 +88,12 @@ public class AtmoConfigScreen extends Screen {
         AtmoCommonConfig.MAX_STORM_DEBRIS_PER_CHUNK.set(parsed);
         AtmoCommonConfig.AUTO_REPAIR_GLASS.set(autoRepairGlass);
         AtmoCommonConfig.DAMAGE_GLASS_ON_TORNADO.set(damageGlassOnTornado);
-        ConfigTracker.INSTANCE.saveConfigs(ModConfig.Type.COMMON);
+        try {
+            ConfigTracker.INSTANCE.saveConfigs(ModConfig.Type.COMMON);
+            errorMessage = null;
+        } catch (Exception e) {
+            errorMessage = Component.literal("Failed to save config: " + e.getMessage());
+        }
     }
 
     @Override

--- a/src/main/java/net/Gabou/projectatmosphere/config/AtmoConfigScreen.java
+++ b/src/main/java/net/Gabou/projectatmosphere/config/AtmoConfigScreen.java
@@ -79,7 +79,9 @@ public class AtmoConfigScreen extends Screen {
         int parsed = this.maxStormDebrisPerChunk;
         try {
             parsed = Integer.parseInt(this.maxDebrisBox.getValue());
+            errorMessage = null;
         } catch (NumberFormatException ignored) {
+            errorMessage = Component.translatable("Invalid number for Max Storm Debris per Chunk.");
         }
         AtmoCommonConfig.FORCE_SHARED_EXECUTOR.set(forceSharedExecutor);
         AtmoCommonConfig.ENABLE_STORM_DEBRIS.set(enableStormDebris);

--- a/src/main/java/net/Gabou/projectatmosphere/config/AtmoConfigScreen.java
+++ b/src/main/java/net/Gabou/projectatmosphere/config/AtmoConfigScreen.java
@@ -1,0 +1,97 @@
+package net.Gabou.projectatmosphere.config;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraftforge.fml.config.ConfigTracker;
+import net.minecraftforge.fml.config.ModConfig;
+
+/**
+ * Simple in-game configuration screen for Project Atmosphere.
+ */
+public class AtmoConfigScreen extends Screen {
+    private final Screen parent;
+    private boolean forceSharedExecutor;
+    private boolean enableStormDebris;
+    private int maxStormDebrisPerChunk;
+    private boolean autoRepairGlass;
+    private boolean damageGlassOnTornado;
+    private EditBox maxDebrisBox;
+
+    public AtmoConfigScreen(Screen parent) {
+        super(Component.literal("Project Atmosphere Config"));
+        this.parent = parent;
+    }
+
+    @Override
+    protected void init() {
+        this.forceSharedExecutor = AtmoCommonConfig.FORCE_SHARED_EXECUTOR.get();
+        this.enableStormDebris = AtmoCommonConfig.ENABLE_STORM_DEBRIS.get();
+        this.maxStormDebrisPerChunk = AtmoCommonConfig.MAX_STORM_DEBRIS_PER_CHUNK.get();
+        this.autoRepairGlass = AtmoCommonConfig.AUTO_REPAIR_GLASS.get();
+        this.damageGlassOnTornado = AtmoCommonConfig.DAMAGE_GLASS_ON_TORNADO.get();
+
+        int center = this.width / 2;
+        int y = 40;
+
+        addRenderableWidget(Button.builder(toggleLabel("Force Shared Executor", forceSharedExecutor), b -> {
+            forceSharedExecutor = !forceSharedExecutor;
+            b.setMessage(toggleLabel("Force Shared Executor", forceSharedExecutor));
+        }).bounds(center - 100, y, 200, 20).build());
+        y += 24;
+
+        addRenderableWidget(Button.builder(toggleLabel("Storm Debris", enableStormDebris), b -> {
+            enableStormDebris = !enableStormDebris;
+            b.setMessage(toggleLabel("Storm Debris", enableStormDebris));
+        }).bounds(center - 100, y, 200, 20).build());
+        y += 24;
+
+        this.maxDebrisBox = new EditBox(this.font, center - 100, y, 200, 20, Component.literal("Max Debris"));
+        this.maxDebrisBox.setValue(Integer.toString(maxStormDebrisPerChunk));
+        addRenderableWidget(this.maxDebrisBox);
+        y += 24;
+
+        addRenderableWidget(Button.builder(toggleLabel("Auto Repair Glass", autoRepairGlass), b -> {
+            autoRepairGlass = !autoRepairGlass;
+            b.setMessage(toggleLabel("Auto Repair Glass", autoRepairGlass));
+        }).bounds(center - 100, y, 200, 20).build());
+        y += 24;
+
+        addRenderableWidget(Button.builder(toggleLabel("Damage Glass On Tornado", damageGlassOnTornado), b -> {
+            damageGlassOnTornado = !damageGlassOnTornado;
+            b.setMessage(toggleLabel("Damage Glass On Tornado", damageGlassOnTornado));
+        }).bounds(center - 100, y, 200, 20).build());
+        y += 24;
+
+        addRenderableWidget(Button.builder(Component.translatable("gui.done"), b -> {
+            saveChanges();
+            Minecraft.getInstance().setScreen(parent);
+        }).bounds(center - 100, this.height - 27, 200, 20).build());
+    }
+
+    private Component toggleLabel(String name, boolean enabled) {
+        return Component.literal(name + ": " + (enabled ? "ON" : "OFF"));
+    }
+
+    private void saveChanges() {
+        int parsed = this.maxStormDebrisPerChunk;
+        try {
+            parsed = Integer.parseInt(this.maxDebrisBox.getValue());
+        } catch (NumberFormatException ignored) {
+        }
+        AtmoCommonConfig.FORCE_SHARED_EXECUTOR.set(forceSharedExecutor);
+        AtmoCommonConfig.ENABLE_STORM_DEBRIS.set(enableStormDebris);
+        AtmoCommonConfig.MAX_STORM_DEBRIS_PER_CHUNK.set(parsed);
+        AtmoCommonConfig.AUTO_REPAIR_GLASS.set(autoRepairGlass);
+        AtmoCommonConfig.DAMAGE_GLASS_ON_TORNADO.set(damageGlassOnTornado);
+        ConfigTracker.INSTANCE.saveConfigs(ModConfig.Type.COMMON);
+    }
+
+    @Override
+    public void onClose() {
+        Minecraft.getInstance().setScreen(parent);
+    }
+}
+

--- a/src/main/java/net/Gabou/projectatmosphere/config/AtmoConfigScreen.java
+++ b/src/main/java/net/Gabou/projectatmosphere/config/AtmoConfigScreen.java
@@ -48,7 +48,7 @@ public class AtmoConfigScreen extends Screen {
         }).bounds(center - 100, y, 200, 20).build());
         y += 24;
 
-        this.maxDebrisBox = new EditBox(this.font, center - 100, y, 200, 20, Component.literal("Max Debris"));
+        this.maxDebrisBox = new EditBox(this.font, center - 100, y, 200, 20, Component.literal("Max Storm Debris Per Chunk"));
         this.maxDebrisBox.setValue(Integer.toString(maxStormDebrisPerChunk));
         addRenderableWidget(this.maxDebrisBox);
         y += 24;


### PR DESCRIPTION
## Summary
- Add an in-game configuration screen allowing players to modify Project Atmosphere settings without editing config files
- Register a config screen factory so the menu is accessible from the mod list

## Testing
- `gradle build --no-daemon` *(stalled during project configuration; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68992e6c9e28833180bfd71f08495cd8