### PR TITLE
Add sand layer block for sandstorm deposition

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/blocks/BlockManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/blocks/BlockManager.java
@@ -6,6 +6,7 @@ import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
 import net.Gabou.projectatmosphere.modules.core.WindVector;
 import net.Gabou.projectatmosphere.registry.ModBlocks;
 import net.Gabou.projectatmosphere.blocks.SandLayerBlock;
+import net.Gabou.projectatmosphere.registry.ModBlocks;
 import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
 import net.Gabou.projectatmosphere.util.AsyncAtmosphereService;
 import net.Gabou.projectatmosphere.util.AtmosphereUtils;

--- a/src/main/java/net/Gabou/projectatmosphere/blocks/BlockManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/blocks/BlockManager.java
@@ -5,6 +5,7 @@ import net.Gabou.projectatmosphere.manager.ForecastGenerator;
 import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
 import net.Gabou.projectatmosphere.modules.core.WindVector;
 import net.Gabou.projectatmosphere.registry.ModBlocks;
+import net.Gabou.projectatmosphere.blocks.SandLayerBlock;
 import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
 import net.Gabou.projectatmosphere.util.AsyncAtmosphereService;
 import net.Gabou.projectatmosphere.util.AtmosphereUtils;
@@ -74,6 +75,57 @@ public class BlockManager {
                             .count() < 6)
             {
                  level.setBlockAndUpdate(dustPos, ModBlocks.DUST.get().defaultBlockState());
+            }
+        }
+    }
+
+    /**
+     * Spawns sand layers around the player depending on wind strength.
+     * Converts to a full sand block once eight layers accumulate.
+     *
+     * @param level The server world
+     * @param centerPos The central position (e.g., player's position)
+     */
+    public static void spawnSand(ServerLevel level, BlockPos centerPos) {
+        RandomSource random = level.getRandom();
+        WindVector windVector = ForecastOrchestrator.getCurrentWind(AtmosphereUtils.getBiomeKey(level, centerPos), level.getGameTime());
+        float windStrength = windVector.baseSpeed();
+        int maxSpawn = Math.min(10, (int)(windStrength * 8));
+
+        for (int i = 0; i < maxSpawn; i++) {
+            if (random.nextFloat() > windStrength) continue;
+
+            double angle = windVector.angleRadians() + (random.nextDouble() - 0.5);
+            double distance = 10 + random.nextDouble() * 10;
+
+            int dx = (int)(Math.cos(angle) * distance);
+            int dz = (int)(Math.sin(angle) * distance);
+            int x = centerPos.getX() + dx;
+            int z = centerPos.getZ() + dz;
+            int y = level.getHeightmapPos(
+                    Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
+                    new BlockPos(x, 0, z)
+            ).getY();
+
+            BlockPos sandPos = new BlockPos(x, y, z);
+            BlockState state = level.getBlockState(sandPos);
+            BlockState groundState = level.getBlockState(sandPos.below());
+
+            boolean validGround = groundState.is(Blocks.DIRT) ||
+                    groundState.is(Blocks.SAND) ||
+                    groundState.is(Blocks.GRAVEL);
+
+            if (!validGround) continue;
+
+            if (state.isAir() || state.is(Blocks.SNOW)) {
+                level.setBlockAndUpdate(sandPos, ModBlocks.SAND_LAYER.get().defaultBlockState());
+            } else if (state.is(ModBlocks.SAND_LAYER.get())) {
+                int layers = state.getValue(SandLayerBlock.LAYERS);
+                if (layers < 8) {
+                    level.setBlockAndUpdate(sandPos, state.setValue(SandLayerBlock.LAYERS, layers + 1));
+                } else {
+                    level.setBlockAndUpdate(sandPos, Blocks.SAND.defaultBlockState());
+                }
             }
         }
     }

--- a/src/main/java/net/Gabou/projectatmosphere/blocks/SandLayerBlock.java
+++ b/src/main/java/net/Gabou/projectatmosphere/blocks/SandLayerBlock.java
@@ -22,7 +22,6 @@ import java.util.List;
  */
 public class SandLayerBlock extends SnowLayerBlock {
     public static final IntegerProperty LAYERS = IntegerProperty.create("layers", 1, 8);
-
     public SandLayerBlock(Properties properties) {
         super(properties);
         this.registerDefaultState(this.stateDefinition.any().setValue(LAYERS, 1));

--- a/src/main/java/net/Gabou/projectatmosphere/blocks/SandLayerBlock.java
+++ b/src/main/java/net/Gabou/projectatmosphere/blocks/SandLayerBlock.java
@@ -1,0 +1,46 @@
+package net.Gabou.projectatmosphere.blocks;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SnowLayerBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.minecraft.world.level.storage.loot.LootParams;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A sand layer block that behaves similarly to snow layers.
+ * Eight layers convert into a full sand block via external logic.
+ */
+public class SandLayerBlock extends SnowLayerBlock {
+    public static final IntegerProperty LAYERS = IntegerProperty.create("layers", 1, 8);
+
+    public SandLayerBlock(Properties properties) {
+        super(properties);
+        this.registerDefaultState(this.stateDefinition.any().setValue(LAYERS, 1));
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+        builder.add(LAYERS);
+    }
+
+    @Override
+    public boolean isCollisionShapeFullBlock(BlockState state, BlockGetter getter, BlockPos pos) {
+        return false;
+    }
+
+    @Override
+    public @NotNull List<ItemStack> getDrops(BlockState state, LootParams.Builder builder) {
+        int layers = state.getValue(LAYERS);
+        return Collections.singletonList(new ItemStack(Items.SAND, layers));
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/blocks/SandLayerBlock.java
+++ b/src/main/java/net/Gabou/projectatmosphere/blocks/SandLayerBlock.java
@@ -41,6 +41,6 @@ public class SandLayerBlock extends SnowLayerBlock {
     @Override
     public @NotNull List<ItemStack> getDrops(BlockState state, LootParams.Builder builder) {
         int layers = state.getValue(LAYERS);
-        return Collections.singletonList(new ItemStack(Items.SAND, layers));
+        return Collections.singletonList(new ItemStack(ModItems.SAND_LAYER.get(), layers));
     }
 }

--- a/src/main/java/net/Gabou/projectatmosphere/registry/ModBlocks.java
+++ b/src/main/java/net/Gabou/projectatmosphere/registry/ModBlocks.java
@@ -28,6 +28,16 @@ public class ModBlocks {
                     .pushReaction(PushReaction.DESTROY)
                     .isViewBlocking((state, getter, pos) -> false)
             ));
+    public static final RegistryObject<Block> SAND_LAYER = REGISTRY.register("sand_layer", () ->
+            new SandLayerBlock(BlockBehaviour.Properties
+                    .of()
+                    .strength(0.1f)
+                    .sound(SoundType.SAND)
+                    .noCollission()
+                    .noOcclusion()
+                    .pushReaction(PushReaction.DESTROY)
+                    .isViewBlocking((state, getter, pos) -> false)
+            ));
     public static final RegistryObject<Block> WEATHER_VANE = REGISTRY.register("weather_vane", () ->
             new WeatherVaneBlock(BlockBehaviour.Properties
                     .of()

--- a/src/main/java/net/Gabou/projectatmosphere/registry/ModItems.java
+++ b/src/main/java/net/Gabou/projectatmosphere/registry/ModItems.java
@@ -90,6 +90,7 @@ public class ModItems {
     }
 
     public static final RegistryObject<Item> DUST = blockUtilities(ModBlocks.DUST);
+    public static final RegistryObject<Item> SAND_LAYER = blockUtilities(ModBlocks.SAND_LAYER);
 
     private static RegistryObject<Item> blockUtilities(RegistryObject<Block> block) {
         return ITEMS.register(block.getId().getPath(), () -> new BlockItem(block.get(), new Item.Properties()));

--- a/src/main/resources/assets/projectatmosphere/blockstates/sand_layer.json
+++ b/src/main/resources/assets/projectatmosphere/blockstates/sand_layer.json
@@ -1,0 +1,12 @@
+{
+  "variants": {
+    "layers=1": { "model": "projectatmosphere:block/sand_layer_1" },
+    "layers=2": { "model": "projectatmosphere:block/sand_layer_2" },
+    "layers=3": { "model": "projectatmosphere:block/sand_layer_3" },
+    "layers=4": { "model": "projectatmosphere:block/sand_layer_4" },
+    "layers=5": { "model": "projectatmosphere:block/sand_layer_5" },
+    "layers=6": { "model": "projectatmosphere:block/sand_layer_6" },
+    "layers=7": { "model": "projectatmosphere:block/sand_layer_7" },
+    "layers=8": { "model": "projectatmosphere:block/sand_layer_8" }
+  }
+}

--- a/src/main/resources/assets/projectatmosphere/lang/en_us.json
+++ b/src/main/resources/assets/projectatmosphere/lang/en_us.json
@@ -9,6 +9,7 @@
   "item.projectatmosphere.balai_diamant": "Diamond Broom",
   "item.projectatmosphere.balai_netherite": "Netherite Broom",
   "block.projectatmosphere.dust": "Dust",
+  "block.projectatmosphere.sand_layer": "Sand Layer",
   "block.projectatmosphere.weather_vane": "Weather Vane",
   "block.projectatmosphere.anemometer": "Anemometer",
   "block.projectatmosphere.thermometer_block": "Thermometer",

--- a/src/main/resources/assets/projectatmosphere/lang/fr_fr.json
+++ b/src/main/resources/assets/projectatmosphere/lang/fr_fr.json
@@ -9,6 +9,7 @@
   "item.projectatmosphere.balai_diamant": "Balai en diamant",
   "item.projectatmosphere.balai_netherite": "Balai en netherite",
   "block.projectatmosphere.dust": "Poussière",
+  "block.projectatmosphere.sand_layer": "Couche de sable",
   "item.projectatmosphere.wind_checker": "Indicateur de vent",
   "block.projectatmosphere.weather_vane": "Girouette",
   "block.projectatmosphere.anemometer": "Anémomètre",

--- a/src/main/resources/assets/projectatmosphere/models/block/sand_layer.json
+++ b/src/main/resources/assets/projectatmosphere/models/block/sand_layer.json
@@ -1,0 +1,7 @@
+{
+  "parent": "block/block",
+  "textures": {
+    "particle": "minecraft:block/sand",
+    "layer": "minecraft:block/sand"
+  }
+}

--- a/src/main/resources/assets/projectatmosphere/models/block/sand_layer_1.json
+++ b/src/main/resources/assets/projectatmosphere/models/block/sand_layer_1.json
@@ -1,0 +1,41 @@
+{
+    "parent": "block/block",
+    "textures": {
+        "particle": "minecraft:block/sand",
+        "layer": "minecraft:block/sand"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                2,
+                16
+            ],
+            "faces": {
+                "up": {
+                    "texture": "#layer"
+                },
+                "down": {
+                    "texture": "#layer"
+                },
+                "north": {
+                    "texture": "#layer"
+                },
+                "south": {
+                    "texture": "#layer"
+                },
+                "west": {
+                    "texture": "#layer"
+                },
+                "east": {
+                    "texture": "#layer"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/projectatmosphere/models/block/sand_layer_2.json
+++ b/src/main/resources/assets/projectatmosphere/models/block/sand_layer_2.json
@@ -1,0 +1,41 @@
+{
+    "parent": "block/block",
+    "textures": {
+        "particle": "minecraft:block/sand",
+        "layer": "minecraft:block/sand"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                4,
+                16
+            ],
+            "faces": {
+                "up": {
+                    "texture": "#layer"
+                },
+                "down": {
+                    "texture": "#layer"
+                },
+                "north": {
+                    "texture": "#layer"
+                },
+                "south": {
+                    "texture": "#layer"
+                },
+                "west": {
+                    "texture": "#layer"
+                },
+                "east": {
+                    "texture": "#layer"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/projectatmosphere/models/block/sand_layer_3.json
+++ b/src/main/resources/assets/projectatmosphere/models/block/sand_layer_3.json
@@ -1,0 +1,41 @@
+{
+    "parent": "block/block",
+    "textures": {
+        "particle": "minecraft:block/sand",
+        "layer": "minecraft:block/sand"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                6,
+                16
+            ],
+            "faces": {
+                "up": {
+                    "texture": "#layer"
+                },
+                "down": {
+                    "texture": "#layer"
+                },
+                "north": {
+                    "texture": "#layer"
+                },
+                "south": {
+                    "texture": "#layer"
+                },
+                "west": {
+                    "texture": "#layer"
+                },
+                "east": {
+                    "texture": "#layer"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/projectatmosphere/models/block/sand_layer_4.json
+++ b/src/main/resources/assets/projectatmosphere/models/block/sand_layer_4.json
@@ -1,0 +1,41 @@
+{
+    "parent": "block/block",
+    "textures": {
+        "particle": "minecraft:block/sand",
+        "layer": "minecraft:block/sand"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                8,
+                16
+            ],
+            "faces": {
+                "up": {
+                    "texture": "#layer"
+                },
+                "down": {
+                    "texture": "#layer"
+                },
+                "north": {
+                    "texture": "#layer"
+                },
+                "south": {
+                    "texture": "#layer"
+                },
+                "west": {
+                    "texture": "#layer"
+                },
+                "east": {
+                    "texture": "#layer"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/projectatmosphere/models/block/sand_layer_5.json
+++ b/src/main/resources/assets/projectatmosphere/models/block/sand_layer_5.json
@@ -1,0 +1,41 @@
+{
+    "parent": "block/block",
+    "textures": {
+        "particle": "minecraft:block/sand",
+        "layer": "minecraft:block/sand"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                10,
+                16
+            ],
+            "faces": {
+                "up": {
+                    "texture": "#layer"
+                },
+                "down": {
+                    "texture": "#layer"
+                },
+                "north": {
+                    "texture": "#layer"
+                },
+                "south": {
+                    "texture": "#layer"
+                },
+                "west": {
+                    "texture": "#layer"
+                },
+                "east": {
+                    "texture": "#layer"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/projectatmosphere/models/block/sand_layer_6.json
+++ b/src/main/resources/assets/projectatmosphere/models/block/sand_layer_6.json
@@ -1,0 +1,41 @@
+{
+    "parent": "block/block",
+    "textures": {
+        "particle": "minecraft:block/sand",
+        "layer": "minecraft:block/sand"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                12,
+                16
+            ],
+            "faces": {
+                "up": {
+                    "texture": "#layer"
+                },
+                "down": {
+                    "texture": "#layer"
+                },
+                "north": {
+                    "texture": "#layer"
+                },
+                "south": {
+                    "texture": "#layer"
+                },
+                "west": {
+                    "texture": "#layer"
+                },
+                "east": {
+                    "texture": "#layer"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/projectatmosphere/models/block/sand_layer_7.json
+++ b/src/main/resources/assets/projectatmosphere/models/block/sand_layer_7.json
@@ -1,0 +1,41 @@
+{
+    "parent": "block/block",
+    "textures": {
+        "particle": "minecraft:block/sand",
+        "layer": "minecraft:block/sand"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                14,
+                16
+            ],
+            "faces": {
+                "up": {
+                    "texture": "#layer"
+                },
+                "down": {
+                    "texture": "#layer"
+                },
+                "north": {
+                    "texture": "#layer"
+                },
+                "south": {
+                    "texture": "#layer"
+                },
+                "west": {
+                    "texture": "#layer"
+                },
+                "east": {
+                    "texture": "#layer"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/projectatmosphere/models/block/sand_layer_8.json
+++ b/src/main/resources/assets/projectatmosphere/models/block/sand_layer_8.json
@@ -1,0 +1,41 @@
+{
+    "parent": "block/block",
+    "textures": {
+        "particle": "minecraft:block/sand",
+        "layer": "minecraft:block/sand"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                16,
+                16
+            ],
+            "faces": {
+                "up": {
+                    "texture": "#layer"
+                },
+                "down": {
+                    "texture": "#layer"
+                },
+                "north": {
+                    "texture": "#layer"
+                },
+                "south": {
+                    "texture": "#layer"
+                },
+                "west": {
+                    "texture": "#layer"
+                },
+                "east": {
+                    "texture": "#layer"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/projectatmosphere/models/item/sand_layer.json
+++ b/src/main/resources/assets/projectatmosphere/models/item/sand_layer.json
@@ -1,0 +1,3 @@
+{
+  "parent": "projectatmosphere:block/sand_layer_8"
+}


### PR DESCRIPTION
## Summary
- introduce `SandLayerBlock` with layered sand behavior
- register sand layer block and item
- allow BlockManager to spawn sand layers that eventually form full sand blocks
- add models, blockstates, and translations for the new sand layer

## Testing
- `gradle build` *(fails: Could not resolve plugin 'net.minecraftforge.gradle' due to SSL context errors)*

------
https://chatgpt.com/codex/tasks/task_e_6899520f8da48331a683377d6a1cc8c3