### PR TITLE
Expose forecast API and add TFC compatibility stub

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/api/AtmoApi.java
+++ b/src/main/java/net/Gabou/projectatmosphere/api/AtmoApi.java
@@ -1,6 +1,10 @@
 package net.Gabou.projectatmosphere.api;
 
+import net.Gabou.projectatmosphere.manager.ForecastGenerator;
 import net.Gabou.projectatmosphere.modules.core.BiomeForecast;
+import net.Gabou.projectatmosphere.modules.core.ForecastType;
+import net.Gabou.projectatmosphere.util.AtmosphereUtils;
+import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 
@@ -30,8 +34,8 @@ public class AtmoApi {
      * @return The BiomeForecast for that position
      */
     public BiomeForecast getWeatherForecast(ServerLevel level, BlockPos pos) {
-        
-        return null;
+        BiomeInstanceKey key = AtmosphereUtils.getBiomeKey(level, pos);
+        return ForecastGenerator.getClosestValidForecast(key, ForecastType.TEMPERATURE);
     }
 
     /**

--- a/tfc_compat/README.md
+++ b/tfc_compat/README.md
@@ -3,5 +3,6 @@
 This module provides integration hooks between Project Atmosphere and TerraFirmaCraft.
 Players must install this companion mod alongside both TFC and Project Atmosphere to enable the compatibility features.
 
-At the moment the mod only demonstrates how to query Project Atmosphere's API for weather data.
-Future updates can expand upon this to apply TFC-specific behaviour.
+The module shows how to query Project Atmosphere's API for forecast data and how to read
+the current temperature from TerraFirmaCraft's climate system. Future updates can expand
+upon this to apply TFC-specific behaviour.

--- a/tfc_compat/README.md
+++ b/tfc_compat/README.md
@@ -1,0 +1,7 @@
+# Project Atmosphere TFC Compatibility
+
+This module provides integration hooks between Project Atmosphere and TerraFirmaCraft.
+Players must install this companion mod alongside both TFC and Project Atmosphere to enable the compatibility features.
+
+At the moment the mod only demonstrates how to query Project Atmosphere's API for weather data.
+Future updates can expand upon this to apply TFC-specific behaviour.

--- a/tfc_compat/build.gradle
+++ b/tfc_compat/build.gradle
@@ -7,8 +7,10 @@ version = '0.1.0'
 
 repositories {
     mavenCentral()
+    // Add Forge or other mod repositories here when wiring dependencies.
 }
 
 dependencies {
-    // Placeholder for Project Atmosphere and TerraFirmaCraft dependencies.
+    compileOnly project(':')
+    compileOnly "net.dries007.tfc:TerraFirmaCraft:0.0.0"
 }

--- a/tfc_compat/build.gradle
+++ b/tfc_compat/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id 'java'
+}
+
+group = 'net.Gabou.projectatmosphere'
+version = '0.1.0'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // Placeholder for Project Atmosphere and TerraFirmaCraft dependencies.
+}

--- a/tfc_compat/src/main/java/net/Gabou/projectatmosphere/tfc/TFCCompatMod.java
+++ b/tfc_compat/src/main/java/net/Gabou/projectatmosphere/tfc/TFCCompatMod.java
@@ -1,0 +1,20 @@
+package net.Gabou.projectatmosphere.tfc;
+
+import net.Gabou.projectatmosphere.api.AtmoApi;
+import net.Gabou.projectatmosphere.modules.core.BiomeForecast;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod(TFCCompatMod.MOD_ID)
+public class TFCCompatMod {
+    public static final String MOD_ID = "project_atmosphere_tfc";
+
+    public TFCCompatMod() {
+        // Initialization hook for the compatibility module.
+    }
+
+    public static BiomeForecast sampleForecast(ServerLevel level, BlockPos pos) {
+        return AtmoApi.getInstance().getWeatherForecast(level, pos);
+    }
+}

--- a/tfc_compat/src/main/java/net/Gabou/projectatmosphere/tfc/TFCCompatMod.java
+++ b/tfc_compat/src/main/java/net/Gabou/projectatmosphere/tfc/TFCCompatMod.java
@@ -2,8 +2,10 @@ package net.Gabou.projectatmosphere.tfc;
 
 import net.Gabou.projectatmosphere.api.AtmoApi;
 import net.Gabou.projectatmosphere.modules.core.BiomeForecast;
+import net.dries007.tfc.util.climate.Climate;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
 import net.minecraftforge.fml.common.Mod;
 
 @Mod(TFCCompatMod.MOD_ID)
@@ -16,5 +18,9 @@ public class TFCCompatMod {
 
     public static BiomeForecast sampleForecast(ServerLevel level, BlockPos pos) {
         return AtmoApi.getInstance().getWeatherForecast(level, pos);
+    }
+
+    public static float sampleTemperature(Level level, BlockPos pos) {
+        return Climate.getTemperature(level, pos);
     }
 }


### PR DESCRIPTION
## Summary
- implement getWeatherForecast to query Project Atmosphere's forecast data
- scaffold a separate TFC compatibility mod using the API

## Testing
- `gradle build` *(fails: build did not progress, likely missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689e301244bc833181c2d82f6a616eac