### PR TITLE
Add tornado probability system and debug tools

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/ProjectAtmosphere.java
+++ b/src/main/java/net/Gabou/projectatmosphere/ProjectAtmosphere.java
@@ -13,6 +13,7 @@ import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
 import net.Gabou.projectatmosphere.config.AtmoConfigScreen;
 import net.Gabou.projectatmosphere.util.AsyncAtmosphereService;
 import net.Gabou.projectatmosphere.util.TickCounter;
+import net.Gabou.projectatmosphere.tornado.TornadoProbabilityManager;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.locale.Language;
 import net.minecraft.resources.ResourceLocation;
@@ -133,6 +134,7 @@ public class ProjectAtmosphere {
     private void setup(final FMLCommonSetupEvent event) {
         LOGGER.info("Setting up Project Atmosphere (Common)");
         initModules();
+        TornadoProbabilityManager.init();
         event.enqueueWork(() -> {
             SimpleCloudsAPI.getApi().getHooks().setExternalWeatherControl(true);
         });

--- a/src/main/java/net/Gabou/projectatmosphere/api/ForecastSampling.java
+++ b/src/main/java/net/Gabou/projectatmosphere/api/ForecastSampling.java
@@ -1,0 +1,42 @@
+package net.Gabou.projectatmosphere.api;
+
+import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
+import net.Gabou.projectatmosphere.util.AtmosphereUtils;
+import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+
+public final class ForecastSampling {
+    private ForecastSampling() {}
+
+    public static float getTemperatureC(BiomeInstanceKey key, ServerLevel level) {
+        return ForecastOrchestrator.getCurrentTemperature(key, level.getGameTime());
+    }
+
+    public static float getHumidityPercent(BiomeInstanceKey key, ServerLevel level) {
+        return ForecastOrchestrator.getCurrentHumidity(key, level.getGameTime());
+    }
+
+    public static float getPressureHpa(BiomeInstanceKey key, ServerLevel level) {
+        return ForecastOrchestrator.getCurrentPressure(key, level.getGameTime());
+    }
+
+    public static boolean isStormyClouds(BiomeInstanceKey key, ServerLevel level) {
+        return ForecastOrchestrator.getCurrentStormChance(key, level.getGameTime()) > 0.5f;
+    }
+
+    public static float minNeighborPressureHpa(BiomeInstanceKey key, ServerLevel level) {
+        BlockPos base = key.samplePos();
+        float min = Float.MAX_VALUE;
+        int[] dx = {16, -16, 0, 0};
+        int[] dz = {0, 0, 16, -16};
+        for (int i = 0; i < 4; i++) {
+            BlockPos pos = base.offset(dx[i], 0, dz[i]);
+            BiomeInstanceKey neighbor = AtmosphereUtils.getBiomeKey(level, pos);
+            float p = getPressureHpa(neighbor, level);
+            if (p < min) min = p;
+        }
+        return min == Float.MAX_VALUE ? getPressureHpa(key, level) : min;
+    }
+}
+

--- a/src/main/java/net/Gabou/projectatmosphere/api/WindVector.java
+++ b/src/main/java/net/Gabou/projectatmosphere/api/WindVector.java
@@ -1,0 +1,30 @@
+package net.Gabou.projectatmosphere.api;
+
+import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
+import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
+import net.minecraft.server.level.ServerLevel;
+
+public final class WindVector {
+    private WindVector() {}
+
+    public record WindSample(float speedMps, float directionDeg) {}
+
+    public static WindSample getSurface(BiomeInstanceKey key, ServerLevel level) {
+        net.Gabou.projectatmosphere.modules.core.WindVector w =
+                ForecastOrchestrator.getCurrentWind(key, level.getGameTime());
+        if (w == null) return new WindSample(0f, 0f);
+        return new WindSample(w.baseSpeed(), (float) Math.toDegrees(w.angleRadians()));
+    }
+
+    public static WindSample getOrFallback(BiomeInstanceKey key, ServerLevel level) {
+        return getSurface(key, level);
+    }
+
+    public static WindSample getAloftProxy(BiomeInstanceKey key, ServerLevel level) {
+        WindSample surface = getSurface(key, level);
+        float dir = surface.directionDeg() + (level.random.nextFloat() * 20f - 10f);
+        float speed = surface.speedMps() + 5f;
+        return new WindSample(speed, dir);
+    }
+}
+

--- a/src/main/java/net/Gabou/projectatmosphere/data/TornadoStorageManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/data/TornadoStorageManager.java
@@ -1,0 +1,30 @@
+package net.Gabou.projectatmosphere.data;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
+import net.minecraft.server.level.ServerLevel;
+
+public final class TornadoStorageManager {
+    private static final Map<String, Long> COOLDOWNS = new ConcurrentHashMap<>();
+
+    private TornadoStorageManager() {}
+
+    public static void load(ServerLevel level) {
+        // Placeholder for future persistence
+    }
+
+    public static void save(ServerLevel level) {
+        // Placeholder for future persistence
+    }
+
+    public static void setCooldown(BiomeInstanceKey key, long untilTick) {
+        COOLDOWNS.put(key.toString(), untilTick);
+    }
+
+    public static boolean isOnCooldown(BiomeInstanceKey key, long nowTick) {
+        Long until = COOLDOWNS.get(key.toString());
+        return until != null && nowTick < until;
+    }
+}
+

--- a/src/main/java/net/Gabou/projectatmosphere/manager/ForecastOrchestrator.java
+++ b/src/main/java/net/Gabou/projectatmosphere/manager/ForecastOrchestrator.java
@@ -5,6 +5,9 @@ import net.Gabou.projectatmosphere.compat.SimpleCloudsCompat;
 import net.Gabou.projectatmosphere.modules.core.BiomeForecast;
 import net.Gabou.projectatmosphere.modules.core.WindVector;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
+import net.Gabou.projectatmosphere.data.TornadoStorageManager;
+import net.Gabou.projectatmosphere.tornado.TornadoProbabilityManager;
+import net.Gabou.projectatmosphere.tornado.TornadoConfig;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
@@ -18,6 +21,7 @@ import java.util.UUID;
 
 public class ForecastOrchestrator {
     private static final int MIN_DISTANCE_BETWEEN_CENTERS = ForecastGenerator.RADIUS / 2;
+    private static long lastTornadoCheckTick = 0;
 
 
 
@@ -28,6 +32,7 @@ public class ForecastOrchestrator {
      */
     public static boolean onServerStart(ServerLevel level) {
         ForecastDataStorage.loadAll(level);
+        TornadoStorageManager.load(level);
 
         
         if (ForecastDataStorage.hasCenterData() && ForecastDataStorage.hasForecastData()) {
@@ -63,6 +68,7 @@ public class ForecastOrchestrator {
      */
     public static void onServerStop(ServerLevel level) {
         ForecastDataStorage.saveAll(level);
+        TornadoStorageManager.save(level);
         ForecastGenerator.clearForecasts();
     }
 
@@ -199,6 +205,15 @@ public class ForecastOrchestrator {
 
     public static void tick(ServerLevel level) {
         ForecastGenerator.tickSandstormScheduler(level);
+        long now = level.getGameTime();
+        if (now - lastTornadoCheckTick >= (long) (TornadoConfig.CHECK_INTERVAL_SEC * 20f)) {
+            lastTornadoCheckTick = now;
+            TornadoProbabilityManager.onScheduledCheck(level);
+        }
+    }
+
+    public static Set<BiomeInstanceKey> getActiveBiomeKeys(ServerLevel level) {
+        return ForecastGenerator.getForecastMap().keySet();
     }
 
 

--- a/src/main/java/net/Gabou/projectatmosphere/tornado/TornadoConfig.java
+++ b/src/main/java/net/Gabou/projectatmosphere/tornado/TornadoConfig.java
@@ -1,0 +1,39 @@
+package net.Gabou.projectatmosphere.tornado;
+
+public final class TornadoConfig {
+    private TornadoConfig() {}
+
+    public static float CHECK_INTERVAL_SEC = 60f;
+    public static float BASE_SPAWN_RADIUS_M = 64f;
+
+    // Instability
+    public static float MIN_TEMP_CONTRAST_C = 6f;
+    public static float HUMIDITY_MIN_PERCENT = 65f;
+
+    // Pressure
+    public static float PRESSURE_GRADIENT_GAIN = 10f;
+    public static float PRESSURE_GRADIENT_CAP = 3f;
+
+    // Shear
+    public static float SHEAR_MIN_SPEED_DIFF_MPS = 5f;
+    public static float SHEAR_MIN_DIR_DIFF_DEG = 45f;
+
+    // Storm gating
+    public static float STORM_MULTIPLIER = 1.5f;
+
+    // Risk thresholds
+    public static float RISK_MIN_TO_CONSIDER = 4.0f;
+    public static float BASE_TRIGGER_CHANCE = 0.05f;
+
+    // Aloft proxy
+    public static float LAPSE_RATE_C_PER_100M = 0.65f;
+    public static float ALOFT_DELTA_H_M = 1500f;
+
+    // Intensity scaling
+    public static float INTENSITY_MIN = 0.4f;
+    public static float INTENSITY_MAX = 1.0f;
+
+    // Cooldown
+    public static int CELL_COOLDOWN_MINUTES = 20;
+}
+

--- a/src/main/java/net/Gabou/projectatmosphere/tornado/TornadoDebug.java
+++ b/src/main/java/net/Gabou/projectatmosphere/tornado/TornadoDebug.java
@@ -1,0 +1,61 @@
+package net.Gabou.projectatmosphere.tornado;
+
+import com.mojang.brigadier.arguments.FloatArgumentType;
+import net.Gabou.projectatmosphere.ProjectAtmosphere;
+import net.Gabou.projectatmosphere.util.AtmosphereUtils;
+import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
+import net.Gabou.projectatmosphere.data.TornadoStorageManager;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = ProjectAtmosphere.MODID)
+public final class TornadoDebug {
+    private TornadoDebug() {}
+
+    @SubscribeEvent
+    public static void register(RegisterCommandsEvent event) {
+        event.getDispatcher().register(
+                Commands.literal("weatherdebug")
+                        .requires(src -> src.hasPermission(2))
+                        .then(Commands.literal("tornado")
+                                .then(Commands.literal("risk")
+                                        .executes(ctx -> {
+                                            ServerPlayer player = ctx.getSource().getPlayerOrException();
+                                            ServerLevel level = player.serverLevel();
+                                            BiomeInstanceKey key = AtmosphereUtils.getBiomeKey(level, player.blockPosition());
+                                            float risk = TornadoProbabilityManager.computeRisk(key, level, level.getGameTime());
+                                            ctx.getSource().sendSuccess(
+                                                    () -> Component.literal("Risk: " + risk), false);
+                                            return 1;
+                                        }))
+                                .then(Commands.literal("force")
+                                        .then(Commands.argument("intensity", FloatArgumentType.floatArg(0f, 1f))
+                                                .executes(ctx -> {
+                                                    ServerPlayer player = ctx.getSource().getPlayerOrException();
+                                                    ServerLevel level = player.serverLevel();
+                                                    BiomeInstanceKey key = AtmosphereUtils.getBiomeKey(level, player.blockPosition());
+                                                    float intensity = FloatArgumentType.getFloat(ctx, "intensity");
+                                                    TornadoSpawner.spawn(key, level, intensity);
+                                                    ctx.getSource().sendSuccess(
+                                                            () -> Component.literal("Tornado spawned."), true);
+                                                    return 1;
+                                                })))
+                                .then(Commands.literal("cooldown")
+                                        .then(Commands.literal("reset")
+                                                .executes(ctx -> {
+                                                    ServerPlayer player = ctx.getSource().getPlayerOrException();
+                                                    ServerLevel level = player.serverLevel();
+                                                    BiomeInstanceKey key = AtmosphereUtils.getBiomeKey(level, player.blockPosition());
+                                                    TornadoStorageManager.setCooldown(key, 0);
+                                                    ctx.getSource().sendSuccess(
+                                                            () -> Component.literal("Cooldown cleared."), true);
+                                                    return 1;
+                                                })))));
+    }
+}
+

--- a/src/main/java/net/Gabou/projectatmosphere/tornado/TornadoProbabilityManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/tornado/TornadoProbabilityManager.java
@@ -1,0 +1,95 @@
+package net.Gabou.projectatmosphere.tornado;
+
+import net.Gabou.projectatmosphere.api.ForecastSampling;
+import net.Gabou.projectatmosphere.api.WindVector;
+import net.Gabou.projectatmosphere.data.TornadoStorageManager;
+import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
+import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
+import net.minecraft.server.level.ServerLevel;
+
+public final class TornadoProbabilityManager {
+    private TornadoProbabilityManager() {}
+
+    public static void init() {
+        // No-op for now
+    }
+
+    public static void onScheduledCheck(ServerLevel level) {
+        long now = level.getGameTime();
+        for (BiomeInstanceKey key : ForecastOrchestrator.getActiveBiomeKeys(level)) {
+            if (!isStormy(key, level)) continue;
+            if (isCellOnCooldown(key, level, now)) continue;
+
+            float risk = computeRisk(key, level, now);
+            if (risk < TornadoConfig.RISK_MIN_TO_CONSIDER) continue;
+
+            float chance = TornadoConfig.BASE_TRIGGER_CHANCE * risk;
+            if (level.random.nextFloat() < chance) {
+                float intensity = map(risk,
+                        TornadoConfig.RISK_MIN_TO_CONSIDER,
+                        TornadoConfig.RISK_MIN_TO_CONSIDER + 4f,
+                        TornadoConfig.INTENSITY_MIN,
+                        TornadoConfig.INTENSITY_MAX);
+                TornadoSpawner.spawn(key, level, clamp01(intensity));
+                TornadoStorageManager.setCooldown(key, now + minutesToTicks(TornadoConfig.CELL_COOLDOWN_MINUTES));
+            }
+        }
+    }
+
+    public static float computeRisk(BiomeInstanceKey key, ServerLevel level, long nowTick) {
+        float risk = 0f;
+
+        float tempSurface = ForecastSampling.getTemperatureC(key, level);
+        float humidity = ForecastSampling.getHumidityPercent(key, level);
+        float tempAloft = tempSurface -
+                (TornadoConfig.LAPSE_RATE_C_PER_100M * (TornadoConfig.ALOFT_DELTA_H_M / 100f));
+        float tempContrast = Math.max(0f, tempSurface - tempAloft);
+        risk += (tempContrast / 10f);
+        if (humidity >= TornadoConfig.HUMIDITY_MIN_PERCENT) risk += 1f;
+
+        float pHere = ForecastSampling.getPressureHpa(key, level);
+        float pNear = ForecastSampling.minNeighborPressureHpa(key, level);
+        float pDiff = Math.abs(pHere - pNear) * TornadoConfig.PRESSURE_GRADIENT_GAIN;
+        risk += Math.min(pDiff, TornadoConfig.PRESSURE_GRADIENT_CAP);
+
+        WindVector.WindSample wSurf = WindVector.getOrFallback(key, level);
+        WindVector.WindSample wAloft = WindVector.getAloftProxy(key, level);
+        float speedDiff = Math.abs(wSurf.speedMps() - wAloft.speedMps());
+        float dirDiff = minimalAngleDiffDeg(wSurf.directionDeg(), wAloft.directionDeg());
+        if (speedDiff >= TornadoConfig.SHEAR_MIN_SPEED_DIFF_MPS &&
+                dirDiff >= TornadoConfig.SHEAR_MIN_DIR_DIFF_DEG) {
+            risk += 2f;
+        }
+
+        if (isStormy(key, level)) risk *= TornadoConfig.STORM_MULTIPLIER;
+
+        return risk;
+    }
+
+    public static boolean isCellOnCooldown(BiomeInstanceKey key, ServerLevel level, long nowTick) {
+        return TornadoStorageManager.isOnCooldown(key, nowTick);
+    }
+
+    private static boolean isStormy(BiomeInstanceKey key, ServerLevel level) {
+        return ForecastSampling.isStormyClouds(key, level);
+    }
+
+    private static float minimalAngleDiffDeg(float a, float b) {
+        float d = Math.abs(((a - b + 540f) % 360f) - 180f);
+        return d;
+    }
+
+    private static long minutesToTicks(float m) {
+        return (long) (m * 20f * 60f);
+    }
+
+    private static float map(float v, float inMin, float inMax, float outMin, float outMax) {
+        float t = (v - inMin) / Math.max(0.0001f, (inMax - inMin));
+        return outMin + (clamp01(t) * (outMax - outMin));
+    }
+
+    private static float clamp01(float x) {
+        return Math.max(0f, Math.min(1f, x));
+    }
+}
+

--- a/src/main/java/net/Gabou/projectatmosphere/tornado/TornadoSpawner.java
+++ b/src/main/java/net/Gabou/projectatmosphere/tornado/TornadoSpawner.java
@@ -1,0 +1,33 @@
+package net.Gabou.projectatmosphere.tornado;
+
+import net.Gabou.projectatmosphere.api.WindVector;
+import net.Gabou.projectatmosphere.modules.tornado.TornadoManager;
+import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.phys.Vec3;
+
+public final class TornadoSpawner {
+    private TornadoSpawner() {}
+
+    public static void spawn(BiomeInstanceKey key, ServerLevel level, float intensity) {
+        BlockPos center = pickSpawnPosNear(key, level, TornadoConfig.BASE_SPAWN_RADIUS_M);
+        WindVector.WindSample wind = WindVector.getSurface(key, level);
+        float radius = 5f + 20f * intensity;
+        net.Gabou.projectatmosphere.modules.core.WindVector w =
+                net.Gabou.projectatmosphere.modules.core.WindVector.fromBase(wind.speedMps(),
+                        (float) Math.toRadians(wind.directionDeg()));
+        TornadoManager.spawnServer(level, Vec3.atCenterOf(center), radius, w);
+    }
+
+    private static BlockPos pickSpawnPosNear(BiomeInstanceKey key, ServerLevel level, float radius) {
+        BlockPos base = key.samplePos();
+        int r = (int) radius;
+        int dx = level.random.nextInt(-r, r + 1);
+        int dz = level.random.nextInt(-r, r + 1);
+        int y = level.getHeight(net.minecraft.world.level.levelgen.Heightmap.Types.MOTION_BLOCKING,
+                base.getX() + dx, base.getZ() + dz);
+        return new BlockPos(base.getX() + dx, y, base.getZ() + dz);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add configurable tornado probability pipeline with risk computation and spawning
- Expose forecast and wind sampling helpers and simple cooldown storage
- Hook tornado checks into forecast tick and add debug commands

## Testing
- `gradle build` *(fails: Daemon started but build output not available)*

------
https://chatgpt.com/codex/tasks/task_e_689f2b7433348331b1ffd4025bd93725