### PR TITLE
Integrate tornado spawns with wind engine and add config

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/api/WindVector.java
+++ b/src/main/java/net/Gabou/projectatmosphere/api/WindVector.java
@@ -1,6 +1,5 @@
 package net.Gabou.projectatmosphere.api;
 
-import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
 import net.minecraft.server.level.ServerLevel;
 
@@ -10,10 +9,9 @@ public final class WindVector {
     public record WindSample(float speedMps, float directionDeg) {}
 
     public static WindSample getSurface(BiomeInstanceKey key, ServerLevel level) {
-        net.Gabou.projectatmosphere.modules.core.WindVector w =
-                ForecastOrchestrator.getCurrentWind(key, level.getGameTime());
-        if (w == null) return new WindSample(0f, 0f);
-        return new WindSample(w.baseSpeed(), (float) Math.toDegrees(w.angleRadians()));
+        net.Gabou.projectatmosphere.modules.core.WindVector.WindSample w =
+                net.Gabou.projectatmosphere.modules.core.WindVector.getOrFallback(key, level);
+        return new WindSample(w.speedMps(), w.directionDeg());
     }
 
     public static WindSample getOrFallback(BiomeInstanceKey key, ServerLevel level) {

--- a/src/main/java/net/Gabou/projectatmosphere/config/AtmoCommonConfig.java
+++ b/src/main/java/net/Gabou/projectatmosphere/config/AtmoCommonConfig.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 
 public class AtmoCommonConfig {
     public static final ForgeConfigSpec.BooleanValue FORCE_SHARED_EXECUTOR;
+    public static final ForgeConfigSpec.BooleanValue ENABLE_TORNADOES;
     public static final ForgeConfigSpec.BooleanValue ENABLE_STORM_DEBRIS;
     public static final ForgeConfigSpec.IntValue MAX_STORM_DEBRIS_PER_CHUNK;
     public static final ForgeConfigSpec.BooleanValue AUTO_REPAIR_GLASS;
@@ -31,6 +32,9 @@ public class AtmoCommonConfig {
                 .define("forceSharedExecutor", false);
         builder.pop();
         builder.push("storms");
+        ENABLE_TORNADOES = builder
+                .comment("Enable tornado spawning and commands")
+                .define("enableTornadoes", true);
         ENABLE_STORM_DEBRIS = builder
                 .comment("Enable random debris spawning during storms")
                 .define("enableStormDebris", true);

--- a/src/main/java/net/Gabou/projectatmosphere/event/EventHandler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/event/EventHandler.java
@@ -9,17 +9,12 @@ import net.Gabou.projectatmosphere.blocks.BlockManager;
 import net.Gabou.projectatmosphere.manager.AtmosphereManager;
 import net.Gabou.projectatmosphere.manager.SimpleCloudSpawner;
 import net.Gabou.projectatmosphere.modules.core.CloudLibrary;
-import net.Gabou.projectatmosphere.modules.core.WindVector;
 import net.Gabou.projectatmosphere.modules.tornado.TornadoManager;
 import net.Gabou.projectatmosphere.modules.tornado.GlassDamageManager;
-import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
-import net.Gabou.projectatmosphere.util.AtmosphereUtils;
-import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -32,9 +27,6 @@ public class EventHandler {
     
     
     private static final int MIN_TICKS_BETWEEN_TEMPESTA = 2000;
-
-    private static final int TICKS_BETWEEN_TORNADO_CHECK = 200;
-    private static final float NATURAL_TORNADO_CHANCE = 0.01f;
 
     private static int tickCounter = 0;
 
@@ -85,17 +77,6 @@ public class EventHandler {
 
         }
 
-        if (tickCounter % TICKS_BETWEEN_TORNADO_CHECK == 0) {
-            for (CloudRegion region : generator.getClouds()) {
-                int severity = CloudLibrary.getSeverityFromRessourceLocation(region.getCloudTypeId());
-                if (severity >= 6 && serverLevel.random.nextFloat() < NATURAL_TORNADO_CHANCE) {
-                    BlockPos spawnPos = new BlockPos((int) region.getPosX(), serverLevel.getSeaLevel(), (int) region.getPosZ());
-                    BiomeInstanceKey key = AtmosphereUtils.getBiomeKey(serverLevel, spawnPos);
-                    WindVector wind = ForecastOrchestrator.getCurrentWind(key, serverLevel.getGameTime());
-                    TornadoManager.spawnServer(serverLevel, new Vec3(spawnPos.getX(), spawnPos.getY(), spawnPos.getZ()), 4.0f, wind);
-                }
-            }
-        }
         ticksSinceLastCloudSpawn++;
         tickCounter++;
     }

--- a/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoCommand.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoCommand.java
@@ -1,7 +1,7 @@
 package net.Gabou.projectatmosphere.modules.tornado;
 
+import net.Gabou.projectatmosphere.api.WindVector;
 import net.Gabou.projectatmosphere.compat.SimpleCloudsCompat;
-import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
 import net.Gabou.projectatmosphere.util.AtmosphereUtils;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
 import net.minecraft.commands.Commands;
@@ -28,8 +28,11 @@ public class TornadoCommand {
                     BiomeInstanceKey key = new BiomeInstanceKey(
                             AtmosphereUtils.getBiomeLocation(player.blockPosition(), level),
                             player.blockPosition());
-                    var wind = ForecastOrchestrator.getCurrentWind(key,level.getGameTime());
-                   SimpleCloudsCompat.spawnCloudInBiome("cumulonimbus", key, level, null, wind);
+                    WindVector.WindSample sample = WindVector.getOrFallback(key, level);
+                    net.Gabou.projectatmosphere.modules.core.WindVector wind =
+                            net.Gabou.projectatmosphere.modules.core.WindVector.fromBase(sample.speedMps(),
+                                    (float) Math.toRadians(sample.directionDeg()));
+                    SimpleCloudsCompat.spawnCloudInBiome("cumulonimbus", key, level, null, wind);
 
                     Vec3 playerPos = player.position();
                     TornadoManager.spawnServer(level,

--- a/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoManager.java
@@ -1,5 +1,6 @@
 package net.Gabou.projectatmosphere.modules.tornado;
 
+import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
 import net.Gabou.projectatmosphere.modules.core.WindVector;
 import net.Gabou.projectatmosphere.network.NetworkHandler;
 import net.Gabou.projectatmosphere.network.SpawnTornadoPacket;
@@ -16,6 +17,7 @@ public class TornadoManager {
     private static float shaderTime = 0.0f;
 
     public static void spawn(Vec3 pos, float radius, WindVector wind) {
+        if (!AtmoCommonConfig.ENABLE_TORNADOES.get()) return;
         ACTIVE_TORNADOES.add(new TornadoInstance(pos, radius, wind));
     }
 

--- a/src/main/java/net/Gabou/projectatmosphere/tornado/TornadoProbabilityManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/tornado/TornadoProbabilityManager.java
@@ -2,6 +2,7 @@ package net.Gabou.projectatmosphere.tornado;
 
 import net.Gabou.projectatmosphere.api.ForecastSampling;
 import net.Gabou.projectatmosphere.api.WindVector;
+import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
 import net.Gabou.projectatmosphere.data.TornadoStorageManager;
 import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
@@ -15,6 +16,7 @@ public final class TornadoProbabilityManager {
     }
 
     public static void onScheduledCheck(ServerLevel level) {
+        if (!AtmoCommonConfig.ENABLE_TORNADOES.get()) return;
         long now = level.getGameTime();
         for (BiomeInstanceKey key : ForecastOrchestrator.getActiveBiomeKeys(level)) {
             if (!isStormy(key, level)) continue;


### PR DESCRIPTION
## Summary
- Remove legacy tornado spawning from server tick handler
- Wire tornado spawning to new wind engine and command
- Add config option to disable tornadoes entirely

## Testing
- `gradle build` *(fails: Plugin [id: 'net.minecraftforge.gradle', version: '[6.0.16,6.2)'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f2f15b594833186ae8aae2f946d5e