### PR TITLE
Add tornado level system

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/weather/Tornado.java
+++ b/src/main/java/net/Gabou/projectatmosphere/weather/Tornado.java
@@ -1,0 +1,21 @@
+package net.Gabou.projectatmosphere.weather;
+
+public class Tornado {
+    private final TornadoLevel level;
+
+    public Tornado(int windSpeed) {
+        this.level = TornadoLevel.fromWindSpeed(windSpeed);
+    }
+
+    public TornadoLevel getLevel() {
+        return level;
+    }
+
+    public double getSuctionRadius() {
+        return level.getBaseDamage() * 2;
+    }
+
+    public double getDamageMultiplier() {
+        return level.getBaseDamage();
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/weather/TornadoLevel.java
+++ b/src/main/java/net/Gabou/projectatmosphere/weather/TornadoLevel.java
@@ -1,0 +1,40 @@
+package net.Gabou.projectatmosphere.weather;
+
+public enum TornadoLevel {
+    F1(73, 112, 5.0),
+    F2(113, 157, 10.0),
+    F3(158, 206, 20.0),
+    F4(207, 260, 40.0),
+    F5(261, 318, 80.0);
+
+    private final int minWindSpeed;
+    private final int maxWindSpeed;
+    private final double baseDamage;
+
+    TornadoLevel(int minWindSpeed, int maxWindSpeed, double baseDamage) {
+        this.minWindSpeed = minWindSpeed;
+        this.maxWindSpeed = maxWindSpeed;
+        this.baseDamage = baseDamage;
+    }
+
+    public int getMinWindSpeed() {
+        return minWindSpeed;
+    }
+
+    public int getMaxWindSpeed() {
+        return maxWindSpeed;
+    }
+
+    public double getBaseDamage() {
+        return baseDamage;
+    }
+
+    public static TornadoLevel fromWindSpeed(int windSpeed) {
+        for (TornadoLevel level : values()) {
+            if (windSpeed >= level.minWindSpeed && windSpeed <= level.maxWindSpeed) {
+                return level;
+            }
+        }
+        return F1;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `TornadoLevel` enum describing F1–F5 tornado categories with wind speed ranges and base damage values
- Implement `Tornado` class to derive suction radius and damage multipliers based on wind speed data

## Testing
- `gradle build` *(fails: terminated while downloading mappings)*

------
https://chatgpt.com/codex/tasks/task_e_689f82bb659483318926308a838b9e5d