### PR TITLE
Add basic hurricane server mechanics and commands

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/event/EventHandler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/event/EventHandler.java
@@ -12,6 +12,7 @@ import net.Gabou.projectatmosphere.modules.core.CloudLibrary;
 import net.Gabou.projectatmosphere.modules.core.WindVector;
 import net.Gabou.projectatmosphere.modules.tornado.TornadoManager;
 import net.Gabou.projectatmosphere.modules.tornado.GlassDamageManager;
+import net.Gabou.projectatmosphere.modules.hurricane.HurricaneManager;
 import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
 import net.Gabou.projectatmosphere.util.AtmosphereUtils;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
@@ -60,6 +61,7 @@ public class EventHandler {
         CloudGenerator generator = cloudManager.getCloudGenerator();
         AtmosphereManager.tick(serverLevel);
         TornadoManager.tick(serverLevel);
+        HurricaneManager.tick(serverLevel);
         GlassDamageManager.tick(serverLevel);
         if (generator.getTicksTillNextGen() <= 0 && ticksSinceLastCloudSpawn % 1000 == 0) {
             SimpleCloudSpawner.trySpawnClouds(serverLevel, generator);

--- a/src/main/java/net/Gabou/projectatmosphere/modules/hurricane/HurricaneCategory.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/hurricane/HurricaneCategory.java
@@ -1,0 +1,32 @@
+package net.Gabou.projectatmosphere.modules.hurricane;
+
+/**
+ * Saffir–Simpson hurricane wind scale categories with
+ * sustained wind speed ranges in miles per hour.
+ */
+public enum HurricaneCategory {
+    ONE(74, 95),
+    TWO(96, 110),
+    THREE(111, 129),
+    FOUR(130, 156),
+    FIVE(157, Integer.MAX_VALUE);
+
+    public final int minMph;
+    public final int maxMph;
+
+    HurricaneCategory(int minMph, int maxMph) {
+        this.minMph = minMph;
+        this.maxMph = maxMph;
+    }
+
+    public static HurricaneCategory fromId(int id) {
+        return switch (id) {
+            case 1 -> ONE;
+            case 2 -> TWO;
+            case 3 -> THREE;
+            case 4 -> FOUR;
+            case 5 -> FIVE;
+            default -> ONE;
+        };
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/modules/hurricane/HurricaneCommand.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/hurricane/HurricaneCommand.java
@@ -1,0 +1,76 @@
+package net.Gabou.projectatmosphere.modules.hurricane;
+
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
+import net.Gabou.projectatmosphere.util.AtmosphereUtils;
+import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.BiomeTags;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import sereneseasons.api.season.Season;
+import sereneseasons.api.season.SeasonHelper;
+
+@Mod.EventBusSubscriber
+public class HurricaneCommand {
+    @SubscribeEvent
+    public static void register(RegisterCommandsEvent event) {
+        var base = Commands.literal("spawnHurricane")
+                .requires(source -> source.hasPermission(2))
+                .then(Commands.argument("category", IntegerArgumentType.integer(1,5))
+                        .executes(ctx -> {
+                            ServerPlayer player = ctx.getSource().getPlayerOrException();
+                            ServerLevel level = player.serverLevel();
+                            if (!level.dimension().equals(Level.OVERWORLD)) return 0;
+                            var pos = player.blockPosition();
+                            var biome = level.getBiome(pos);
+                            if (!biome.is(BiomeTags.IS_OCEAN) || biome.value().getBaseTemperature() < 0.8f) {
+                                ctx.getSource().sendFailure(Component.literal("Hurricanes can only spawn in warm oceans."));
+                                return 0;
+                            }
+                            Season.SubSeason sub = SeasonHelper.getSeasonState(level).getSubSeason();
+                            if (sub.ordinal() < Season.SubSeason.LATE_SPRING.ordinal() || sub.ordinal() > Season.SubSeason.EARLY_AUTUMN.ordinal()) {
+                                ctx.getSource().sendFailure(Component.literal("Hurricanes only spawn between late spring and early fall."));
+                                return 0;
+                            }
+                            int catInt = IntegerArgumentType.getInteger(ctx, "category");
+                            HurricaneCategory cat = HurricaneCategory.fromId(catInt);
+                            BiomeInstanceKey key = new BiomeInstanceKey(AtmosphereUtils.getBiomeLocation(pos, level), pos);
+                            var wind = ForecastOrchestrator.getCurrentWind(key, level.getGameTime());
+                            Vec3 spawnPos = new Vec3(player.getX(), level.getSeaLevel(), player.getZ());
+                            HurricaneManager.spawnServer(level, spawnPos, 40f, wind, cat);
+                            ctx.getSource().sendSuccess(() -> Component.literal("🌀 Hurricane category " + catInt + " spawned."), true);
+                            return 1;
+                        }));
+        event.getDispatcher().register(base);
+        event.getDispatcher().register(Commands.literal("clearhurricanes")
+                .requires(source -> source.hasPermission(2))
+                .executes(ctx -> {
+                    HurricaneManager.clearHurricanes();
+                    ctx.getSource().sendSuccess(() -> Component.literal("🌀 All hurricanes cleared."), true);
+                    return 1;
+                }));
+        event.getDispatcher().register(Commands.literal("removehurricane")
+                .requires(source -> source.hasPermission(2))
+                .executes(ctx -> {
+                    ServerPlayer player = ctx.getSource().getPlayerOrException();
+                    Vec3 playerPos = player.position();
+                    HurricaneInstance hurricane = HurricaneManager.getActiveHurricanes().stream()
+                            .filter(h -> h.position.distanceToSqr(playerPos) < 400)
+                            .findFirst().orElse(null);
+                    if (hurricane != null) {
+                        HurricaneManager.removeHurricane(hurricane);
+                        ctx.getSource().sendSuccess(() -> Component.literal("🌀 Hurricane removed."), true);
+                    } else {
+                        ctx.getSource().sendFailure(Component.literal("No hurricane found near you."));
+                    }
+                    return 1;
+                }));
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/modules/hurricane/HurricaneInstance.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/hurricane/HurricaneInstance.java
@@ -1,0 +1,63 @@
+package net.Gabou.projectatmosphere.modules.hurricane;
+
+import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.server.level.ServerLevel;
+
+/**
+ * Represents a server-side hurricane event.
+ */
+public class HurricaneInstance {
+
+    public Vec3 position;
+    public final long spawnTime;
+    public final float radius;
+    public final WindVector wind;
+    public final HurricaneCategory category;
+
+    private long lastAmbientWindCheck = 0L;
+    private final long ambientWindIntervalMs = 2000L;
+
+    public HurricaneInstance(Vec3 position, float radius, WindVector wind, HurricaneCategory category) {
+        this.position = position;
+        this.radius = radius;
+        this.wind = wind;
+        this.category = category;
+        this.spawnTime = System.currentTimeMillis();
+    }
+
+    public float getLifetimeSeconds() {
+        return (System.currentTimeMillis() - spawnTime) / 1000f;
+    }
+
+    public void tick(Level level) {
+        if (level.isClientSide) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        if (now - lastAmbientWindCheck >= ambientWindIntervalMs) {
+            lastAmbientWindCheck = now;
+            applyAmbientWind((ServerLevel) level);
+        }
+    }
+
+    private void applyAmbientWind(ServerLevel level) {
+        double influence = radius;
+        AABB box = new AABB(
+                position.x - influence, position.y - 5,
+                position.z - influence, position.x + influence,
+                position.y + 50, position.z + influence
+        );
+
+        double windSpeed = wind.gustSpeed() * 0.02f;
+        double vx = Math.cos(wind.angleRadians()) * windSpeed;
+        double vz = Math.sin(wind.angleRadians()) * windSpeed;
+
+        for (Entity entity : level.getEntities(null, box)) {
+            entity.push(vx, 0, vz);
+        }
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/modules/hurricane/HurricaneManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/hurricane/HurricaneManager.java
@@ -1,0 +1,42 @@
+package net.Gabou.projectatmosphere.modules.hurricane;
+
+import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class HurricaneManager {
+
+    private static final List<HurricaneInstance> ACTIVE_HURRICANES = new ArrayList<>();
+
+    public static void spawnServer(ServerLevel level, Vec3 pos, float radius, WindVector wind, HurricaneCategory category) {
+        ACTIVE_HURRICANES.add(new HurricaneInstance(pos, radius, wind, category));
+    }
+
+    public static void tick(ServerLevel level) {
+        ACTIVE_HURRICANES.removeIf(h -> h.getLifetimeSeconds() > 1200);
+        for (HurricaneInstance hurricane : ACTIVE_HURRICANES) {
+            float speed = hurricane.wind.baseSpeed() * 0.01f;
+            hurricane.position = hurricane.position.add(
+                    Math.cos(hurricane.wind.angleRadians()) * speed,
+                    0,
+                    Math.sin(hurricane.wind.angleRadians()) * speed);
+            hurricane.tick(level);
+        }
+    }
+
+    public static List<HurricaneInstance> getActiveHurricanes() {
+        return Collections.unmodifiableList(ACTIVE_HURRICANES);
+    }
+
+    public static void clearHurricanes() {
+        ACTIVE_HURRICANES.clear();
+    }
+
+    public static void removeHurricane(HurricaneInstance hurricane) {
+        ACTIVE_HURRICANES.remove(hurricane);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement hurricane categories using Saffir-Simpson wind ranges
- Add hurricane instance, manager, and spawn/clear commands gated by biome and season
- Tick active hurricanes alongside tornadoes on the server

## Testing
- `gradle build` *(fails: Plugin [id: 'net.minecraftforge.gradle'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f830c07d483318f9e4036309bc6e8