### PR TITLE
Update active biome tracking

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/event/BiomeChangeManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/event/BiomeChangeManager.java
@@ -4,6 +4,7 @@ import com.BreadRes.desertstormwarming.sounds.SandstormSounds;
 import net.Gabou.projectatmosphere.manager.AtmosphereManager;
 import net.Gabou.projectatmosphere.manager.ForecastDataStorage;
 import net.Gabou.projectatmosphere.manager.ForecastGenerator;
+import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
 import net.Gabou.projectatmosphere.modules.sandStorm.SandStormAPI;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
@@ -103,9 +104,11 @@ public class BiomeChangeManager {
         BlockPos currentPos = player.blockPosition();
         BlockPos originalCenter = ForecastDataStorage.playerData.get(uuid);
 
-        
+        ForecastOrchestrator.clearActiveBiomeKeysForPlayer(player);
+        ForecastOrchestrator.getNearbyBiomeKeys(player.serverLevel(), player, 500);
+
         if (originalCenter == null || originalCenter.distManhattan(currentPos) > MIN_DISTANCE_BETWEEN_CENTERS) {
-            ForecastDataStorage.playerData.put(uuid, currentPos); 
+            ForecastDataStorage.playerData.put(uuid, currentPos);
             AtmosphereManager.updateForecastAround(player.serverLevel(), currentPos);
 
             player.sendSystemMessage(net.minecraft.network.chat.Component.literal(

--- a/src/main/java/net/Gabou/projectatmosphere/manager/AtmosphereManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/manager/AtmosphereManager.java
@@ -115,7 +115,8 @@ public class AtmosphereManager {
         });
     }
 
-    public static void   onRegenerate(ServerLevel world) {
+    public static void onRegenerate(ServerLevel world) {
+        ForecastOrchestrator.clearActiveBiomeKeys();
         AsyncAtmosphereService.runWeather(() -> {
             ForecastGenerator.clearBiomeSamples();
             EventHandler.onRegenerate();

--- a/src/main/java/net/Gabou/projectatmosphere/manager/ForecastOrchestrator.java
+++ b/src/main/java/net/Gabou/projectatmosphere/manager/ForecastOrchestrator.java
@@ -117,6 +117,7 @@ public class ForecastOrchestrator {
      */
     public static void clearAndRegenerate(ServerLevel level, Set<BlockPos> centers) {
         ForecastGenerator.clearForecasts();
+        clearActiveBiomeKeys();
         ForecastDataStorage.playerData.clear();
 
         for (BlockPos center : centers) {


### PR DESCRIPTION
## Summary
- refresh active biome keys for players when their biome changes
- clear active biome tracking on forecast regeneration

## Testing
- `gradle build` *(fails: Index 3 out of bounds for length 2)*

------
https://chatgpt.com/codex/tasks/task_e_689fb73d5f5c833198cd9bc525d27299