### PR TITLE
Integrate seasonal snowstorm logic

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/manager/SimpleCloudSpawner.java
+++ b/src/main/java/net/Gabou/projectatmosphere/manager/SimpleCloudSpawner.java
@@ -23,6 +23,9 @@ import net.minecraft.util.valueproviders.BiasedToBottomInt;
 import org.joml.Vector2i;
 
 import java.util.*;
+import net.minecraftforge.fml.ModList;
+import sereneseasons.api.season.Season;
+import sereneseasons.api.season.SeasonHelper;
 
 import static net.Gabou.projectatmosphere.compat.SimpleCloudsCompat.MAX_RADIUS;
 import static net.Gabou.projectatmosphere.compat.SimpleCloudsCompat.MIN_RADIUS;
@@ -86,15 +89,25 @@ public class SimpleCloudSpawner {
             if (stats == null) continue;
 
             
-            String cloudId = CloudLibrary.getCloudIdFromSeverity(
-                    determineCloudSeverity(
-                            stats.temperature(),
-                            stats.humidity(),
-                            stats.pressure(),
-                            calculateDewPoint(stats.temperature(), stats.humidity()),
-                            stats.stormChance()
-                    )
+            boolean isWinter = ModList.get().isLoaded("sereneseasons") &&
+                    SeasonHelper.getSeasonState(level).getSeason() == Season.WINTER;
+            boolean freezing = stats.temperature() <= 0.0F;
+            int severity = determineCloudSeverity(
+                    stats.temperature(),
+                    stats.humidity(),
+                    stats.pressure(),
+                    calculateDewPoint(stats.temperature(), stats.humidity()),
+                    stats.stormChance()
             );
+            String cloudId;
+            if (isWinter || freezing) {
+                cloudId = CloudLibrary.getSnowstormCloudId();
+            } else {
+                cloudId = CloudLibrary.getCloudIdFromSeverity(severity);
+                if (CloudLibrary.isThunderCloud(cloudId) && (isWinter || freezing)) {
+                    cloudId = CloudLibrary.getCloudIdFromSeverity(5);
+                }
+            }
 
             ResourceLocation rl = ResourceLocation.fromNamespaceAndPath(SimpleCloudsMod.MODID, cloudId);
             CloudSpawningConfig.Info info = config.getWeightInfo(rl);

--- a/src/main/java/net/Gabou/projectatmosphere/modules/core/CloudLibrary.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/core/CloudLibrary.java
@@ -2,10 +2,25 @@ package net.Gabou.projectatmosphere.modules.core;
 
 import net.minecraft.resources.ResourceLocation;
 import java.util.Random;
+import java.util.Set;
 
 public class CloudLibrary {
 
     private static final Random RANDOM = new Random();
+
+    private static final String[] SNOWSTORM_CLOUDS = {
+            "snow",
+            "nimbostratus",
+            "severe_nimbostratus"
+    };
+
+    private static final Set<String> THUNDER_CLOUDS = Set.of(
+            "cumulonimbus",
+            "severe_cumulonimbus",
+            "tsegrus",
+            "dense_tsegrus",
+            "dark_wall"
+    );
 
     private static final String[] SEVERITY_7_CLOUDS = {
             "cumulonimbus",
@@ -83,6 +98,14 @@ public class CloudLibrary {
             case 2 -> getRandomFrom(SEVERITY_2_CLOUDS);
             default -> getRandomFrom(SEVERITY_1_CLOUDS);
         };
+    }
+
+    public static String getSnowstormCloudId() {
+        return getRandomFrom(SNOWSTORM_CLOUDS);
+    }
+
+    public static boolean isThunderCloud(String id) {
+        return THUNDER_CLOUDS.contains(id);
     }
 
     public static int getSeverityFromCloudId(String id) {

--- a/src/main/java/net/Gabou/projectatmosphere/modules/snowstorm/SnowstormManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/snowstorm/SnowstormManager.java
@@ -29,26 +29,41 @@ public class SnowstormManager {
             BlockPos pos = player.blockPosition();
             Biome biome = level.getBiome(pos).value();
             if (biome.coldEnoughToSnow(pos)) {
-                applyEffects(player);
-                updateSnowstormConfig();
+                int intensity = forecastBlockCount(20 * 60);
+                applyEffects(player, intensity);
+                updateSnowstormConfig(intensity);
             }
         }
     }
 
-    private static void applyEffects(ServerPlayer player) {
+    private static void applyEffects(ServerPlayer player, int intensity) {
         player.addEffect(new MobEffectInstance(MobEffects.BLINDNESS, 40, 0, false, false));
-        applyFreezingCompat(player);
-        int forecast = forecastBlockCount(20 * 60);
-        player.displayClientMessage(Component.literal("Snow forecast: " + forecast + " blocks"), true);
+        triggerTemperatureEffect(player);
+        player.displayClientMessage(Component.literal("Snow forecast: " + intensity + " blocks"), true);
     }
 
-    private static void applyFreezingCompat(ServerPlayer player) {
-        if (ModList.get().isLoaded("toughasnails") || ModList.get().isLoaded("legendarysurvivaloverhaul") || ModList.get().isLoaded("coldsweat")) {
+    private static final String[] TEMPERATURE_MODS = {
+            "toughasnails",
+            "legendarysurvivaloverhaul",
+            "coldsweat"
+    };
+
+    private static boolean isTemperatureModLoaded() {
+        for (String mod : TEMPERATURE_MODS) {
+            if (ModList.get().isLoaded(mod)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void triggerTemperatureEffect(ServerPlayer player) {
+        if (isTemperatureModLoaded()) {
             player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, 40, 0, false, false));
         }
     }
 
-    private static void updateSnowstormConfig() {
+    private static void updateSnowstormConfig(int intensity) {
         if (!ModList.get().isLoaded("sereneseasonsplus")) {
             return;
         }
@@ -57,6 +72,7 @@ public class SnowstormManager {
         try (CommentedFileConfig config = CommentedFileConfig.builder(configPath).sync().build()) {
             config.load();
             config.set("snowstorm.enabled", true);
+            config.set("snowstorm.intensity", intensity);
             config.save();
         } catch (Exception e) {
             ProjectAtmosphere.LOGGER.warn("Failed to update Serene Seasons Plus config: {}", e.getMessage());


### PR DESCRIPTION
## Summary
- Add snowstorm and thundercloud helpers to CloudLibrary
- Restrict thundercloud spawns during winter or freezing temperatures
- Update snowstorm manager to apply intensity-based config and temperature mod effects

## Testing
- `gradle build --console=plain` *(fails: build hung during dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68a25a567fc08331baddfd0ed30e1a02