### PR TITLE
Add tornado spawn scheduling and distance culling

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/client/ClientRenderHook.java
+++ b/src/main/java/net/Gabou/projectatmosphere/client/ClientRenderHook.java
@@ -43,19 +43,21 @@ public class ClientRenderHook {
 
 
         for (TornadoInstance tornado : tornadoes) {
-            try{
+            try {
+                if (tornado.position.distanceToSqr(camPos) > 500 * 500) {
+                    continue;
+                }
                 TornadoRenderHandler.renderTornado(
                         poseStack,
                         tornado.position.x,
                         Minecraft.getInstance().level.getSeaLevel(),
                         tornado.position.z,
                         tornado.getTwist(),
-                        level,camera,Minecraft.getInstance(),tornado
+                        level, camera, Minecraft.getInstance(), tornado
 
                 );
-                
-            }
-            catch (Exception e){
+
+            } catch (Exception e) {
                 ProjectAtmosphere.LOGGER.error("Error rendering tornado at position: " + tornado.position, e);
             }
 

--- a/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoProbabilityManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoProbabilityManager.java
@@ -1,14 +1,19 @@
 package net.Gabou.projectatmosphere.modules.tornado;
 
+import dev.nonamecrackers2.simpleclouds.common.cloud.region.CloudRegion;
+import dev.nonamecrackers2.simpleclouds.common.cloud.spawning.CloudGenerator;
+import dev.nonamecrackers2.simpleclouds.common.world.CloudManager;
+import dev.nonamecrackers2.simpleclouds.common.world.ServerCloudManager;
 import net.Gabou.projectatmosphere.api.ForecastSampling;
 import net.Gabou.projectatmosphere.api.WindVector;
 import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
 import net.Gabou.projectatmosphere.data.TornadoStorageManager;
 import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
+import net.Gabou.projectatmosphere.modules.core.CloudLibrary;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
+import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 
-import java.util.Objects;
 
 public final class TornadoProbabilityManager {
     private TornadoProbabilityManager() {}
@@ -20,6 +25,7 @@ public final class TornadoProbabilityManager {
     public static void onScheduledCheck(ServerLevel level) {
         if (!AtmoCommonConfig.ENABLE_TORNADOES.get()) return;
         long now = level.getGameTime();
+        if (!TornadoSpawnScheduler.isSlotAvailable(now)) return;
         for (BiomeInstanceKey key : ForecastOrchestrator.getActiveBiomeKeys(level)) {//TODO fill this first
             if (!isStormy(key, level)) continue;
             if (isCellOnCooldown(key, level, now)) continue;
@@ -28,17 +34,16 @@ public final class TornadoProbabilityManager {
             float riskMin = AtmoCommonConfig.TORNADO_RISK_MIN_TO_CONSIDER.get().floatValue();
             if (risk < riskMin) continue;
 
-            float chance = AtmoCommonConfig.TORNADO_BASE_TRIGGER_CHANCE.get().floatValue() * risk;
-            if (level.random.nextFloat() < chance) {
-                float intensity = map(risk,
-                        riskMin,
-                        riskMin + 4f,
-                        AtmoCommonConfig.TORNADO_INTENSITY_MIN.get().floatValue(),
-                        AtmoCommonConfig.TORNADO_INTENSITY_MAX.get().floatValue());
-                TornadoSpawner.spawn(key, level, clamp01(intensity));
-                TornadoStorageManager.setCooldown(key,
-                        now + minutesToTicks(AtmoCommonConfig.TORNADO_CELL_COOLDOWN_MINUTES.get()));
-            }
+            float intensity = map(risk,
+                    riskMin,
+                    riskMin + 4f,
+                    AtmoCommonConfig.TORNADO_INTENSITY_MIN.get().floatValue(),
+                    AtmoCommonConfig.TORNADO_INTENSITY_MAX.get().floatValue());
+            TornadoSpawner.spawn(key, level, clamp01(intensity));
+            TornadoStorageManager.setCooldown(key,
+                    now + minutesToTicks(AtmoCommonConfig.TORNADO_CELL_COOLDOWN_MINUTES.get()));
+            TornadoSpawnScheduler.recordSpawn(now);
+            break;
         }
     }
 
@@ -80,7 +85,20 @@ public final class TornadoProbabilityManager {
     }
 
     private static boolean isStormy(BiomeInstanceKey key, ServerLevel level) {
-        return ForecastSampling.isStormyClouds(key, level);
+        ServerCloudManager manager = (ServerCloudManager) CloudManager.get(level);
+        CloudGenerator generator = manager.getCloudGenerator();
+        BlockPos pos = key.samplePos();
+        for (CloudRegion region : generator.getClouds()) {
+            int severity = CloudLibrary.getSeverityFromRessourceLocation(region.getCloudTypeId());
+            if (severity < 7) continue;
+            double dx = region.getPosX() - pos.getX();
+            double dz = region.getPosZ() - pos.getZ();
+            double r = region.getRadius();
+            if (dx * dx + dz * dz <= r * r) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static float minimalAngleDiffDeg(float a, float b) {

--- a/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoSpawnScheduler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/tornado/TornadoSpawnScheduler.java
@@ -1,0 +1,52 @@
+package net.Gabou.projectatmosphere.modules.tornado;
+
+/**
+ * Manages tornado spawn slots and cooldowns.
+ * Allows up to three simultaneous tornadoes with staggered initial availability
+ * and per-slot cooldowns after spawning.
+ */
+public final class TornadoSpawnScheduler {
+    private static final int MAX_TORNADOES = 3;
+    private static final long MINUTES_TO_TICKS = 20L * 60L;
+    private static final long INITIAL_DELAY_TICKS = 30L * MINUTES_TO_TICKS;
+    private static final long SLOT_INTERVAL_TICKS = 20L * MINUTES_TO_TICKS;
+    private static final long COOLDOWN_TICKS = 60L * MINUTES_TO_TICKS;
+
+    private static final long[] slotReadyTicks = new long[MAX_TORNADOES];
+
+    static {
+        for (int i = 0; i < MAX_TORNADOES; i++) {
+            slotReadyTicks[i] = INITIAL_DELAY_TICKS + (i * SLOT_INTERVAL_TICKS);
+        }
+    }
+
+    private TornadoSpawnScheduler() {}
+
+    /**
+     * Returns true if there is at least one slot ready for spawning and the
+     * active tornado count is below the allowed maximum.
+     */
+    public static boolean isSlotAvailable(long nowTick) {
+        if (TornadoManager.getActiveTornadoes().size() >= MAX_TORNADOES) {
+            return false;
+        }
+        for (long ready : slotReadyTicks) {
+            if (nowTick >= ready) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Marks the earliest available slot as used, placing it on cooldown.
+     */
+    public static void recordSpawn(long nowTick) {
+        for (int i = 0; i < slotReadyTicks.length; i++) {
+            if (nowTick >= slotReadyTicks[i]) {
+                slotReadyTicks[i] = nowTick + COOLDOWN_TICKS;
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add TornadoSpawnScheduler to manage three spawn slots with cooldowns
- ensure tornadoes only spawn under cumulonimbus clouds and remove random chance
- skip rendering tornadoes more than 500 blocks away

## Testing
- `gradle -Dnet.minecraftforge.gradle.check.certs=false build` *(fails: Task :extractSrg)*


------
https://chatgpt.com/codex/tasks/task_e_68a25cc28c708331a4835b0ab7c00d1e