### PR TITLE
Use Serene Seasons Plus helper for snowstorms

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/manager/AtmosphereManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/manager/AtmosphereManager.java
@@ -141,7 +141,7 @@ public class AtmosphereManager {
         ForecastOrchestrator.tick(level);
         TornadoManager.tick(level);
         HurricaneManager.tick(level);
-        //SnowstormManager.tick(level);
+        SnowstormManager.tick(level);
     }
 
 

--- a/src/main/java/net/Gabou/projectatmosphere/manager/SimpleCloudSpawner.java
+++ b/src/main/java/net/Gabou/projectatmosphere/manager/SimpleCloudSpawner.java
@@ -10,6 +10,7 @@ import net.Gabou.projectatmosphere.ProjectAtmosphere;
 import net.Gabou.projectatmosphere.compat.SimpleCloudsCompat;
 import net.Gabou.projectatmosphere.modules.core.CloudLibrary;
 import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.Gabou.projectatmosphere.modules.snowstorm.SnowstormManager;
 import net.Gabou.projectatmosphere.util.AtmosphereUtils;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
 import net.Gabou.projectatmosphere.util.WeatherSampler;
@@ -99,10 +100,13 @@ public class SimpleCloudSpawner {
                     calculateDewPoint(stats.temperature(), stats.humidity()),
                     stats.stormChance()
             );
+            boolean snowstorm = severity > 5 && freezing;
             String cloudId;
-            if (isWinter || freezing) {
+            if (snowstorm) {
+                SnowstormManager.startSnowstorm(severity);
                 cloudId = CloudLibrary.getSnowstormCloudId();
             } else {
+                SnowstormManager.stopSnowstorm();
                 cloudId = CloudLibrary.getCloudIdFromSeverity(severity);
                 if (CloudLibrary.isThunderCloud(cloudId) && (isWinter || freezing)) {
                     cloudId = CloudLibrary.getCloudIdFromSeverity(5);

--- a/src/main/java/net/Gabou/projectatmosphere/modules/snowstorm/SnowstormManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/snowstorm/SnowstormManager.java
@@ -1,7 +1,6 @@
 package net.Gabou.projectatmosphere.modules.snowstorm;
 
-import com.electronwill.nightconfig.core.file.CommentedFileConfig;
-import net.Gabou.projectatmosphere.ProjectAtmosphere;
+import com.Gabou.sereneseasonsplus.util.SnowstormHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
@@ -10,36 +9,44 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraftforge.fml.ModList;
-import net.minecraftforge.fml.config.ConfigTracker;
-import net.minecraftforge.fml.config.ModConfig;
-import net.minecraftforge.fml.loading.FMLPaths;
-
-import java.nio.file.Path;
 
 public class SnowstormManager {
 
-    private static final double ACCUMULATION_RATE_PER_TICK = 1.0 / 1200.0;
+    private static double accumulationRatePerTick = 0.0;
+    private static boolean snowstormActive = false;
+
+    public static void startSnowstorm(int intensity) {
+        SnowstormHelper.startSnowstorm(intensity);
+        snowstormActive = true;
+        accumulationRatePerTick = intensity / 1200.0;
+    }
+
+    public static void stopSnowstorm() {
+        SnowstormHelper.stopSnowstorm();
+        snowstormActive = false;
+        accumulationRatePerTick = 0.0;
+    }
 
     public static void tick(ServerLevel level) {
-        if (!level.isRaining()) {
+        if (!snowstormActive) {
             return;
         }
+
+        int forecast = forecastBlockCount(20 * 60);
 
         for (ServerPlayer player : level.players()) {
             BlockPos pos = player.blockPosition();
             Biome biome = level.getBiome(pos).value();
             if (biome.coldEnoughToSnow(pos)) {
-                int intensity = forecastBlockCount(20 * 60);
-                applyEffects(player, intensity);
-                updateSnowstormConfig(intensity);
+                applyEffects(player, forecast);
             }
         }
     }
 
-    private static void applyEffects(ServerPlayer player, int intensity) {
+    private static void applyEffects(ServerPlayer player, int forecast) {
         player.addEffect(new MobEffectInstance(MobEffects.BLINDNESS, 40, 0, false, false));
         triggerTemperatureEffect(player);
-        player.displayClientMessage(Component.literal("Snow forecast: " + intensity + " blocks"), true);
+        player.displayClientMessage(Component.literal("Snow forecast: " + forecast + " blocks"), true);
     }
 
     private static final String[] TEMPERATURE_MODS = {
@@ -63,21 +70,7 @@ public class SnowstormManager {
         }
     }
 
-    private static void updateSnowstormConfig(int intensity) {
-        Path configPath = FMLPaths.CONFIGDIR.get().resolve("sereneseasonsplus-common.toml");
-        try (CommentedFileConfig config = CommentedFileConfig.builder(configPath).sync().build()) {
-            config.load();
-            config.set("snowstorm.enabled", true);
-            config.set("snowstorm.intensity", intensity);
-            config.save();
-        } catch (Exception e) {
-            ProjectAtmosphere.LOGGER.warn("Failed to update Serene Seasons Plus config: {}", e.getMessage());
-        }
-
-        ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.COMMON, FMLPaths.CONFIGDIR.get());
-    }
-
     public static int forecastBlockCount(int durationTicks) {
-        return (int) (durationTicks * ACCUMULATION_RATE_PER_TICK);
+        return (int) (durationTicks * accumulationRatePerTick);
     }
 }


### PR DESCRIPTION
## Summary
- Start Serene Seasons Plus snowstorms when severe cold clouds spawn
- Manage snowstorm state and accumulation rate through SnowstormManager
- Tick snowstorms only when active to apply effects and forecast snowfall

## Testing
- `gradle build` *(fails: Cannot deobfuscate dependency of type DefaultFileCollectionDependency_Decorated)*

------
https://chatgpt.com/codex/tasks/task_e_68a358626570833181bfe1cfe7ac8580