### PR TITLE
Bind hurricanes to renderer and spawn custom cumulonimbus

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/manager/ForecastOrchestrator.java
+++ b/src/main/java/net/Gabou/projectatmosphere/manager/ForecastOrchestrator.java
@@ -11,6 +11,7 @@ import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
 import net.Gabou.projectatmosphere.data.TornadoStorageManager;
 import net.Gabou.projectatmosphere.storms.HurricaneState;
 import net.Gabou.projectatmosphere.modules.tornado.TornadoProbabilityManager;
+import net.Gabou.projectatmosphere.modules.hurricane.HurricaneManager;
 import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
 
 import net.Gabou.projectatmosphere.wind.FloatRange;
@@ -302,7 +303,13 @@ public class ForecastOrchestrator {
 
 
     public static HurricaneState getActiveHurricane() {
-        return null;
+        var hurricanes = HurricaneManager.getActiveHurricanes();
+        if (hurricanes.isEmpty()) {
+            return null;
+        }
+
+        var h = hurricanes.get(0);
+        return new HurricaneState(h.position.x, h.position.z, h.radius, h.radius * 0.5);
     }
 
 }

--- a/src/main/java/net/Gabou/projectatmosphere/modules/core/CloudLibrary.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/core/CloudLibrary.java
@@ -19,7 +19,8 @@ public class CloudLibrary {
             "severe_cumulonimbus",
             "tsegrus",
             "dense_tsegrus",
-            "dark_wall"
+            "dark_wall",
+            "custom_cumulonimbus"
     );
 
     private static final String[] SEVERITY_7_CLOUDS = {
@@ -27,7 +28,8 @@ public class CloudLibrary {
             "severe_cumulonimbus",
             "tsegrus",
             "dense_tsegrus",
-            "dark_wall"
+            "dark_wall",
+            "custom_cumulonimbus"
     };
 
     private static final String[] SEVERITY_6_CLOUDS = {
@@ -110,7 +112,7 @@ public class CloudLibrary {
 
     public static int getSeverityFromCloudId(String id) {
         return switch (id) {
-            case "cumulonimbus", "severe_cumulonimbus", "tsegrus", "dense_tsegrus", "dark_wall" -> 7;
+            case "cumulonimbus", "severe_cumulonimbus", "tsegrus", "dense_tsegrus", "dark_wall", "custom_cumulonimbus" -> 7;
             case "nimbostratus", "severe_nimbostratus" -> 6;
             case "stratocumulus", "dense_stratocumulus", "smaller_stratocumulus", "thicker_stratocumulus", "dithering",
                     "islands", "pathway", "spots", "spotted", "stripe", "stripe_side" -> 5;

--- a/src/main/java/net/Gabou/projectatmosphere/modules/hurricane/HurricaneCommand.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/hurricane/HurricaneCommand.java
@@ -2,6 +2,7 @@ package net.Gabou.projectatmosphere.modules.hurricane;
 
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
+import net.Gabou.projectatmosphere.compat.SimpleCloudsCompat;
 import net.Gabou.projectatmosphere.util.AtmosphereUtils;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
 import net.minecraft.commands.Commands;
@@ -43,6 +44,7 @@ public class HurricaneCommand {
                             HurricaneCategory cat = HurricaneCategory.fromId(catInt);
                             BiomeInstanceKey key = new BiomeInstanceKey(AtmosphereUtils.getBiomeLocation(pos, level), pos);
                             var wind = ForecastOrchestrator.getCurrentWind(key, level.getGameTime());
+                            SimpleCloudsCompat.spawnCloudInBiome("custom_cumulonimbus", key, level, null, wind);
                             Vec3 spawnPos = new Vec3(player.getX(), level.getSeaLevel(), player.getZ());
                             HurricaneManager.spawnServer(level, spawnPos, 40f, wind, cat);
                             ctx.getSource().sendSuccess(() -> Component.literal("🌀 Hurricane category " + catInt + " spawned."), true);

--- a/src/main/resources/data/simpleclouds/cloud_spawning/custom_cumulonimbus.json
+++ b/src/main/resources/data/simpleclouds/cloud_spawning/custom_cumulonimbus.json
@@ -1,0 +1,41 @@
+{
+    "type": "simpleclouds:custom_cumulonimbus",
+    "exist_ticks": {
+        "type": "minecraft:biased_to_bottom",
+        "value": {
+            "max_inclusive": 48000,
+            "min_inclusive": 24000
+        }
+    },
+    "grow_ticks": {
+        "type": "minecraft:biased_to_bottom",
+        "value": {
+            "max_inclusive": 6000,
+            "min_inclusive": 3000
+        }
+    },
+    "moves_to_player": true,
+    "order_weight": 1200,
+    "radius": {
+        "type": "minecraft:biased_to_bottom",
+        "value": {
+            "max_inclusive": 6000,
+            "min_inclusive": 3000
+        }
+    },
+    "speed": {
+        "type": "minecraft:uniform",
+        "value": {
+            "max_exclusive": 0.4,
+            "min_inclusive": 0.2
+        }
+    },
+    "stretch_factor": {
+        "type": "minecraft:uniform",
+        "value": {
+            "max_exclusive": 0.4,
+            "min_inclusive": 0.2
+        }
+    },
+    "weight": 1
+}

--- a/src/main/resources/data/simpleclouds/cloud_types/custom_cumulonimbus.json
+++ b/src/main/resources/data/simpleclouds/cloud_types/custom_cumulonimbus.json
@@ -1,0 +1,58 @@
+{
+    "noise_settings": [
+        {
+            "scale_z": 900.0,
+            "fade_distance": 128.0,
+            "height_offset": 0.0,
+            "value_scale": 1.0,
+            "height": 280.0,
+            "value_offset": 0.15,
+            "scale_x": 1100.0,
+            "scale_y": 1100.0
+        },
+        {
+            "scale_z": 55.0,
+            "fade_distance": 48.0,
+            "height_offset": 20.0,
+            "value_scale": 1.2,
+            "height": 140.0,
+            "value_offset": 1.35,
+            "scale_x": 55.0,
+            "scale_y": 55.0
+        },
+        {
+            "scale_z": 220.0,
+            "fade_distance": 96.0,
+            "height_offset": 10.0,
+            "value_scale": 0.85,
+            "height": 220.0,
+            "value_offset": 0.5,
+            "scale_x": 220.0,
+            "scale_y": 220.0
+        },
+        {
+            "scale_z": 320.0,
+            "fade_distance": 128.0,
+            "height_offset": 6.0,
+            "value_scale": 0.7,
+            "height": 220.0,
+            "value_offset": 0.45,
+            "scale_x": 320.0,
+            "scale_y": 320.0
+        },
+        {
+            "scale_z": 12.0,
+            "fade_distance": 24.0,
+            "height_offset": 28.0,
+            "value_scale": 1.0,
+            "height": 90.0,
+            "value_offset": 1.1,
+            "scale_x": 12.0,
+            "scale_y": 12.0
+        }
+    ],
+    "weather_type": "thunderstorm",
+    "storminess": 1.0,
+    "storm_start": 48.0,
+    "storm_fade_distance": 160.0
+}


### PR DESCRIPTION
## Summary
- link active hurricanes to renderer by exposing active instance
- spawn a custom cumulonimbus cloud when using /spawnHurricane
- register custom cumulonimbus cloud definitions and severity metadata

## Testing
- `gradle build` *(fails: Plugin [id: 'net.minecraftforge.gradle'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a35b22f5d88331a1a397874014922b