### PR TITLE
Stabilize hurricane center rendering and custom cloud

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/mixin/SimpleCloudsRendererMixin.java
+++ b/src/main/java/net/Gabou/projectatmosphere/mixin/SimpleCloudsRendererMixin.java
@@ -26,7 +26,7 @@ public abstract class SimpleCloudsRendererMixin {
         self.translateClouds(stack, camX, camY, camZ);
 
         // Draw hurricane ring in cloud space (y≈0 is cloud plane)
-        HurricaneMeshRenderer.renderCloudSpace(self, stack, projMat, partialTick);
+        HurricaneMeshRenderer.renderCloudSpace(self, stack, projMat, partialTick, camX, camZ);
 
         stack.popPose();
     }

--- a/src/main/java/net/Gabou/projectatmosphere/render/HurricaneMeshRenderer.java
+++ b/src/main/java/net/Gabou/projectatmosphere/render/HurricaneMeshRenderer.java
@@ -18,12 +18,17 @@ public final class HurricaneMeshRenderer {
 
     /** Draw a flat eye-wall ring in Simple Clouds' cloud space. */
     public static void renderCloudSpace(SimpleCloudsRenderer sc, PoseStack pose,
-                                        Matrix4f proj, float partialTick) {
+                                        Matrix4f proj, float partialTick,
+                                        double camX, double camZ) {
         var mc = Minecraft.getInstance();
-        if (mc.level == null) return;
+        if (mc.level == null) {
+            return;
+        }
 
-        var state = HurricaneStateProvider.getActive(); // implemented below
-        if (state == null) return;
+        var state = HurricaneStateProvider.getActive(camX, camZ);
+        if (state == null) {
+            return;
+        }
 
         // Center & radii are expected in *cloud space* units
         float cx = (float) state.centerXCloudSpace();

--- a/src/main/java/net/Gabou/projectatmosphere/render/HurricaneStateProvider.java
+++ b/src/main/java/net/Gabou/projectatmosphere/render/HurricaneStateProvider.java
@@ -6,15 +6,21 @@ import net.Gabou.projectatmosphere.common.SimpleCloudsBridge;
 public final class HurricaneStateProvider {
     private HurricaneStateProvider() {}
 
-    /** Return active hurricane, or null. Must provide cloud-space coords/radii. */
-    public static HurricaneStateCloudSpace getActive() {
-        var s = ForecastOrchestrator.getActiveHurricane(); // your existing API
-        if (s == null) return null;
+    /**
+     * Return active hurricane, or {@code null}. Coordinates are converted from world
+     * space to Simple Clouds' cloud space by subtracting the camera position and
+     * dividing by the cloud scale.
+     */
+    public static HurricaneStateCloudSpace getActive(double camX, double camZ) {
+        var s = ForecastOrchestrator.getActiveHurricane();
+        if (s == null) {
+            return null;
+        }
 
-        double scale = SimpleCloudsBridge.getCloudScale(); // return SimpleCloudsConstants.CLOUD_SCALE
+        double scale = SimpleCloudsBridge.getCloudScale();
         return new HurricaneStateCloudSpace(
-            s.centerX() / scale,
-            s.centerZ() / scale,
+            (s.centerX() - camX) / scale,
+            (s.centerZ() - camZ) / scale,
             s.eyeRadius() / scale,
             s.eyewallFade() / scale
         );

--- a/src/main/resources/data/simpleclouds/cloud_spawning/custom_cumulonimbus.json
+++ b/src/main/resources/data/simpleclouds/cloud_spawning/custom_cumulonimbus.json
@@ -14,7 +14,7 @@
             "min_inclusive": 3000
         }
     },
-    "moves_to_player": true,
+    "moves_to_player": false,
     "order_weight": 1200,
     "radius": {
         "type": "minecraft:biased_to_bottom",


### PR DESCRIPTION
## Summary
- Anchor hurricane eye rendering to world coordinates by accounting for camera position
- Pass camera coordinates through mixin and renderer layers
- Keep custom cumulonimbus cloud stationary instead of following the player

## Testing
- `PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68a3b085a9448331898e7b4f16010420