### PR TITLE
feat: add storm siren block

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/blocks/StormSirenBlock.java
+++ b/src/main/java/net/Gabou/projectatmosphere/blocks/StormSirenBlock.java
@@ -1,0 +1,47 @@
+package net.Gabou.projectatmosphere.blocks;
+
+import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
+import net.Gabou.projectatmosphere.util.WeatherSampler;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.Set;
+
+/**
+ * Block that acts as a storm siren. Periodically samples the surrounding
+ * biomes for storm intensity and plays a warning sound when a dangerous
+ * storm is nearby.
+ */
+public class StormSirenBlock extends Block {
+    private static final int CHECK_RADIUS = 400;
+    private static final float INTENSITY_THRESHOLD = 6.0f;
+
+    public StormSirenBlock(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean isMoving) {
+        super.onPlace(state, level, pos, oldState, isMoving);
+        if (!level.isClientSide) {
+            level.scheduleTick(pos, this, 20);
+        }
+    }
+
+    @Override
+    public void tick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
+        Set<BiomeInstanceKey> keys = WeatherSampler.sampleBiomesInArea(pos.getX(), pos.getZ(), CHECK_RADIUS, level);
+        WeatherSampler.WeatherStats stats = WeatherSampler.computeWeatherStats(keys, level, level.getGameTime());
+        if (stats != null && stats.stormChance() > INTENSITY_THRESHOLD) {
+            level.playSound(null, pos, SoundEvents.RAID_HORN, SoundSource.BLOCKS, 1.0f, 1.0f);
+        }
+        level.scheduleTick(pos, this, 20);
+    }
+}
+

--- a/src/main/java/net/Gabou/projectatmosphere/registry/ModBlocks.java
+++ b/src/main/java/net/Gabou/projectatmosphere/registry/ModBlocks.java
@@ -78,4 +78,12 @@ public class ModBlocks {
                     .noOcclusion()
             ));
 
+    public static final RegistryObject<Block> STORM_SIREN = REGISTRY.register("storm_siren", () ->
+            new StormSirenBlock(BlockBehaviour.Properties
+                    .of()
+                    .strength(0.5f)
+                    .sound(SoundType.METAL)
+                    .noOcclusion()
+            ));
+
 }

--- a/src/main/java/net/Gabou/projectatmosphere/registry/ModItems.java
+++ b/src/main/java/net/Gabou/projectatmosphere/registry/ModItems.java
@@ -93,6 +93,8 @@ public class ModItems {
     public static final RegistryObject<Item> DUST = blockUtilities(ModBlocks.DUST);
     public static final RegistryObject<Item> SAND_LAYER = blockUtilities(ModBlocks.SAND_LAYER);
 
+    public static final RegistryObject<Item> STORM_SIREN = blockUtilities(ModBlocks.STORM_SIREN);
+
     private static RegistryObject<Item> blockUtilities(RegistryObject<Block> block) {
         return ITEMS.register(block.getId().getPath(), () -> new BlockItem(block.get(), new Item.Properties()));
     }


### PR DESCRIPTION
## Summary
- add storm siren block that polls surrounding biomes for intense storms and plays a warning horn
- register storm siren block and item

## Testing
- `gradle build` *(fails: Plugin [id: 'net.minecraftforge.gradle', version: '[6.0.16,6.2)'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b537c35c83319f812fae2e1a4131