### PR TITLE
Fix custom cumulonimbus noise layers exceeding Simple Clouds limit

### DIFF
--- a/src/main/resources/data/simpleclouds/cloud_types/custom_cumulonimbus.json
+++ b/src/main/resources/data/simpleclouds/cloud_types/custom_cumulonimbus.json
@@ -39,16 +39,6 @@
             "value_offset": 0.45,
             "scale_x": 320.0,
             "scale_y": 320.0
-        },
-        {
-            "scale_z": 12.0,
-            "fade_distance": 24.0,
-            "height_offset": 28.0,
-            "value_scale": 1.0,
-            "height": 90.0,
-            "value_offset": 1.1,
-            "scale_x": 12.0,
-            "scale_y": 12.0
         }
     ],
     "weather_type": "thunderstorm",


### PR DESCRIPTION
## Summary
- Reduce `custom_cumulonimbus` cloud type to four noise layers to respect Simple Clouds' maximum layer limit

## Testing
- `gradle build` *(fails: Plugin [id: 'net.minecraftforge.gradle', version: '[6.0.16,6.2)'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e7792ed0833189e0aa24a2e555e7