### PR TITLE
Add weatherdebug cloud spawn commands

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/command/DebugAtmoCommand.java
+++ b/src/main/java/net/Gabou/projectatmosphere/command/DebugAtmoCommand.java
@@ -1,22 +1,35 @@
 package net.Gabou.projectatmosphere.command;
 
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.context.CommandContext;
+import dev.nonamecrackers2.simpleclouds.common.cloud.region.CloudRegion;
+import dev.nonamecrackers2.simpleclouds.common.cloud.spawning.CloudGenerator;
 import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
 import net.Gabou.projectatmosphere.manager.AtmosphereManager;
 import net.Gabou.projectatmosphere.manager.ForecastGenerator;
+import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
 import net.Gabou.projectatmosphere.manager.SimpleCloudSpawner;
 import net.Gabou.projectatmosphere.modules.core.BiomeForecast;
+import net.Gabou.projectatmosphere.modules.core.CloudLibrary;
+import net.Gabou.projectatmosphere.compat.SimpleCloudsCompat;
 import net.Gabou.projectatmosphere.modules.core.ForecastType;
+import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.Gabou.projectatmosphere.modules.snowstorm.SnowstormManager;
+import net.Gabou.projectatmosphere.util.AtmosphereUtils;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.ResourceLocationArgument;
+import net.minecraft.commands.arguments.coordinates.BlockPosArgument;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
+import sereneseasons.api.season.Season;
+import sereneseasons.api.season.SeasonHelper;
 
 public class DebugAtmoCommand {
     /**
@@ -96,6 +109,36 @@ public class DebugAtmoCommand {
                                     return 1;
                                 })
                         )
+                        .then(Commands.literal("rain")
+                                .executes(DebugAtmoCommand::spawnRain)
+                                .then(Commands.argument("pos", BlockPosArgument.blockPos())
+                                        .executes(DebugAtmoCommand::spawnRain)
+                                        .then(Commands.argument("noThunder", BoolArgumentType.bool())
+                                                .executes(DebugAtmoCommand::spawnRain)
+                                                .then(Commands.argument("intensity", IntegerArgumentType.integer(1, 2))
+                                                        .executes(DebugAtmoCommand::spawnRain)
+                                                )
+                                        )
+                                )
+                        )
+                        .then(Commands.literal("thunder")
+                                .executes(DebugAtmoCommand::spawnThunder)
+                                .then(Commands.argument("pos", BlockPosArgument.blockPos())
+                                        .executes(DebugAtmoCommand::spawnThunder)
+                                        .then(Commands.argument("intensity", IntegerArgumentType.integer(1, 2))
+                                                .executes(DebugAtmoCommand::spawnThunder)
+                                        )
+                                )
+                        )
+                        .then(Commands.literal("snowstorm")
+                                .executes(DebugAtmoCommand::spawnSnowstorm)
+                                .then(Commands.argument("pos", BlockPosArgument.blockPos())
+                                        .executes(DebugAtmoCommand::spawnSnowstorm)
+                                        .then(Commands.argument("overwrite", BoolArgumentType.bool())
+                                                .executes(DebugAtmoCommand::spawnSnowstorm)
+                                        )
+                                )
+                        )
                         .then(Commands.argument("violence", ResourceLocationArgument.id())
                                 .executes(ctx -> {
                                         int violence = SimpleCloudSpawner.getCurrentViolence();
@@ -113,6 +156,99 @@ public class DebugAtmoCommand {
                         )
 
         );
+    }
+
+    private static void spawnCloud(ServerLevel level, BlockPos pos, String cloudId) {
+        CloudGenerator generator = SimpleCloudsCompat.generator;
+        if (generator != null) {
+            CloudRegion existing = generator.getCloudAtWorldPosition(pos.getX(), pos.getZ());
+            if (existing != null) {
+                generator.removeClouds(r -> r == existing);
+            }
+        }
+        BiomeInstanceKey key = new BiomeInstanceKey(AtmosphereUtils.getBiomeLocation(pos, level), pos);
+        WindVector wind = ForecastOrchestrator.getCurrentWind(key, level.getGameTime());
+        SimpleCloudsCompat.spawnCloudInBiome(cloudId, key, level, null, wind);
+    }
+
+    private static int spawnRain(CommandContext<CommandSourceStack> ctx) {
+        ServerLevel level = ctx.getSource().getLevel();
+        BlockPos pos;
+        try {
+            pos = BlockPosArgument.getBlockPos(ctx, "pos");
+        } catch (IllegalArgumentException e) {
+            pos = BlockPos.containing(ctx.getSource().getPosition());
+        }
+        boolean noThunder;
+        try {
+            noThunder = BoolArgumentType.getBool(ctx, "noThunder");
+        } catch (IllegalArgumentException e) {
+            noThunder = false;
+        }
+        int intensity;
+        try {
+            intensity = IntegerArgumentType.getInteger(ctx, "intensity");
+        } catch (IllegalArgumentException e) {
+            intensity = 1;
+        }
+        String cloudId = CloudLibrary.getRandomRainCloud(intensity, !noThunder);
+        spawnCloud(level, pos, cloudId);
+        ctx.getSource().sendSuccess(() -> Component.literal("☔ Spawned rain cloud: " + cloudId), true);
+        return 1;
+    }
+
+    private static int spawnThunder(CommandContext<CommandSourceStack> ctx) {
+        ServerLevel level = ctx.getSource().getLevel();
+        BlockPos pos;
+        try {
+            pos = BlockPosArgument.getBlockPos(ctx, "pos");
+        } catch (IllegalArgumentException e) {
+            pos = BlockPos.containing(ctx.getSource().getPosition());
+        }
+        int intensity;
+        try {
+            intensity = IntegerArgumentType.getInteger(ctx, "intensity");
+        } catch (IllegalArgumentException e) {
+            intensity = 1;
+        }
+        String cloudId = CloudLibrary.getRandomThunderCloud(intensity);
+        spawnCloud(level, pos, cloudId);
+        ctx.getSource().sendSuccess(() -> Component.literal("⚡ Spawned thunder cloud: " + cloudId), true);
+        return 1;
+    }
+
+    private static int spawnSnowstorm(CommandContext<CommandSourceStack> ctx) {
+        ServerLevel level = ctx.getSource().getLevel();
+        BlockPos pos;
+        try {
+            pos = BlockPosArgument.getBlockPos(ctx, "pos");
+        } catch (IllegalArgumentException e) {
+            pos = BlockPos.containing(ctx.getSource().getPosition());
+        }
+        boolean overwrite;
+        try {
+            overwrite = BoolArgumentType.getBool(ctx, "overwrite");
+        } catch (IllegalArgumentException e) {
+            overwrite = false;
+        }
+        if (SeasonHelper.getSeasonState(level).getSeason() != Season.WINTER) {
+            if (!overwrite) {
+                ctx.getSource().sendFailure(Component.literal("It is not winter."));
+                return 0;
+            }
+            try {
+                Object state = SeasonHelper.getSeasonState(level);
+                state.getClass().getMethod("setSeason", Season.class).invoke(state, Season.WINTER);
+            } catch (Exception e) {
+                ctx.getSource().sendFailure(Component.literal("Failed to overwrite season."));
+                return 0;
+            }
+        }
+        String cloudId = CloudLibrary.getSnowstormCloudId();
+        SnowstormManager.startSnowstorm(CloudLibrary.getSeverityFromCloudId(cloudId));
+        spawnCloud(level, pos, cloudId);
+        ctx.getSource().sendSuccess(() -> Component.literal("❄ Spawned snowstorm cloud."), true);
+        return 1;
     }
 
     /**

--- a/src/main/java/net/Gabou/projectatmosphere/modules/core/CloudLibrary.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/core/CloudLibrary.java
@@ -24,6 +24,18 @@ public class CloudLibrary {
             "custom_cumulonimbus"
     );
 
+    private static final String[] THUNDER_LOW_CLOUDS = {
+            "cumulonimbus",
+            "tsegrus",
+            "custom_cumulonimbus"
+    };
+
+    private static final String[] THUNDER_HIGH_CLOUDS = {
+            "severe_cumulonimbus",
+            "dense_tsegrus",
+            "dark_wall"
+    };
+
     private static final String[] SEVERITY_7_CLOUDS = {
             "cumulonimbus",
             "severe_cumulonimbus",
@@ -103,6 +115,18 @@ public class CloudLibrary {
 
     public static String getSnowstormCloudId() {
         return getRandomFrom(SNOWSTORM_CLOUDS);
+    }
+
+    public static String getRandomThunderCloud(int intensity) {
+        return intensity == 2 ? getRandomFrom(THUNDER_HIGH_CLOUDS) : getRandomFrom(THUNDER_LOW_CLOUDS);
+    }
+
+    public static String getRandomRainCloud(int intensity, boolean includeThunder) {
+        if (includeThunder && RANDOM.nextInt(4) == 0) {
+            return getRandomThunderCloud(intensity);
+        }
+        int severity = intensity == 2 ? 6 : 5;
+        return getCloudIdFromSeverity(severity);
     }
 
     public static boolean isThunderCloud(String id) {


### PR DESCRIPTION
## Summary
- add `/weatherdebug rain`, `/weatherdebug thunder`, and `/weatherdebug snowstorm` commands
- support replacing existing cloud regions and optional season override for snowstorms
- extend CloudLibrary with helpers for thunder and rain cloud selection

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68af0ba4ba4483318c7b82728e91d0ab