### PR TITLE
Bias cloud spawning toward storms and sunny days

### DIFF
--- a/src/main/java/net/Gabou/projectatmosphere/compat/SimpleCloudsCompat.java
+++ b/src/main/java/net/Gabou/projectatmosphere/compat/SimpleCloudsCompat.java
@@ -168,15 +168,18 @@ public class SimpleCloudsCompat {
                 if (stats == null)
                     continue;
 
-                String cloudId = CloudLibrary.getCloudIdFromSeverity(
-                        determineCloudSeverity(
-                                stats.temperature(),
-                                stats.humidity(),
-                                stats.pressure(),
-                                calculateDewPoint(stats.temperature(), stats.humidity()),
-                                stats.stormChance(),
-                                level
-                        ));
+                int severity = determineCloudSeverity(
+                        stats.temperature(),
+                        stats.humidity(),
+                        stats.pressure(),
+                        calculateDewPoint(stats.temperature(), stats.humidity()),
+                        stats.stormChance(),
+                        level
+                );
+                if (severity <= 0) {
+                    continue;
+                }
+                String cloudId = CloudLibrary.getCloudIdFromSeverity(severity);
                 ResourceLocation rl = ResourceLocation.fromNamespaceAndPath(SimpleCloudsMod.MODID, cloudId);
                 CloudSpawningConfig.Info selected = config.getWeightInfo(rl);
                 if (selected == null)

--- a/src/main/java/net/Gabou/projectatmosphere/manager/SimpleCloudSpawner.java
+++ b/src/main/java/net/Gabou/projectatmosphere/manager/SimpleCloudSpawner.java
@@ -49,6 +49,9 @@ public class SimpleCloudSpawner {
     private static float HUMIDITY_MODIFIER = 1.0f;
     private static float TEMPERATURE_MODIFIER = 1.0f;
 
+    private static final float STORM_BIAS = 1.2f;
+    private static final float SUNNY_THRESHOLD = 0.6f;
+
     public static int getCurrentViolence() {
         return currentViolence;
     }
@@ -101,6 +104,7 @@ public class SimpleCloudSpawner {
                     calculateDewPoint(stats.temperature(), stats.humidity()),
                     stats.stormChance(), level
             );
+            if (severity <= 0) continue;
             boolean snowstorm = severity > 5 && freezing;
             String cloudId;
             if (snowstorm) {
@@ -189,10 +193,14 @@ public class SimpleCloudSpawner {
 
         float boost = 1f + 0.08f * daysSince;  // +8% per day
         boost = Math.min(boost, 4f);         // cap at 2.5x
-        float adjustedChance = Math.min(1f, stormChance * boost);
+        float adjustedChance = Math.min(1f, stormChance * boost * STORM_BIAS);
 
+        float rawScore = instability * adjustedChance;
+        if (rawScore < SUNNY_THRESHOLD) {
+            return 0;
+        }
 
-        int severity = Math.round(instability * adjustedChance);
+        int severity = Math.round(rawScore);
         severity = Math.max(1, Math.min(7, severity));
 
         if (severity >= 5) {


### PR DESCRIPTION
## Summary
- boost storm severity with `STORM_BIAS` and introduce `SUNNY_THRESHOLD` to allow clear days
- skip cloud generation when calculated severity is calm
- respect new severity check during initial cloud spawning

## Testing
- `gradle build` *(fails: Invalid patcher dependency: de.oceanlabs.mcp:mcp_config:1.20.1-20230612.114412@zip)*

------
https://chatgpt.com/codex/tasks/task_e_68b5456ab4d8833187647a55ef624ee6