### PR TITLE
Synchronize rainbow precipitation tracking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ This file records functionality additions/removals made during development sessi
   - Aurora brightness now scales with Serene Seasons data and is boosted in freezing biomes.
   - Rainbows rely on the Project Atmosphere / Serene Seasons Plus rain helper so they only trigger after custom storms clear.
 - Introduced guarded client mixins plus a rain-state tracker so these integrations activate only when the companion mods are installed.
+- Refined aurora and rainbow compatibility syncing.
+  - Aurora brightness now queries Project Atmosphere’s live temperature data (or active temperature mods) instead of static biome values.
+  - Rainbows receive server-synchronised rainfall intensity from SimpleClouds spawns/despawns, allowing accurate rain stop triggers across dimensions and for joining players.
 
 ## 0.5.5.4 – Non-vanilla biome resolution (2025-10-24)
 - BiomeTempConfig now resolves un-namespaced biome keys by scanning the biome registry.

--- a/src/main/java/net/Gabou/projectatmosphere/client/ClientPacketHandlers.java
+++ b/src/main/java/net/Gabou/projectatmosphere/client/ClientPacketHandlers.java
@@ -1,0 +1,21 @@
+package net.Gabou.projectatmosphere.client;
+
+import net.Gabou.projectatmosphere.compat.rainbows.RainbowWeatherTracker;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+@OnlyIn(Dist.CLIENT)
+public final class ClientPacketHandlers {
+
+    private ClientPacketHandlers() {
+    }
+
+    public static void handleRainfallUpdate(ResourceLocation dimensionId, float rainLevel) {
+        ResourceKey<Level> key = ResourceKey.create(Registries.DIMENSION, dimensionId);
+        RainbowWeatherTracker.applyServerUpdate(key, rainLevel);
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/compat/auroras/AuroraSeasonHelper.java
+++ b/src/main/java/net/Gabou/projectatmosphere/compat/auroras/AuroraSeasonHelper.java
@@ -1,12 +1,13 @@
 package net.Gabou.projectatmosphere.compat.auroras;
 
+import net.Gabou.projectatmosphere.compat.temperature.ClientTemperatureResolver;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraft.util.Mth;
 import sereneseasons.api.season.Season;
 import sereneseasons.api.season.SeasonHelper;
 
@@ -47,9 +48,12 @@ public final class AuroraSeasonHelper {
         if (biome.coldEnoughToSnow(pos)) {
             return 1.35f;
         }
-        float baseTemp = biome.getBaseTemperature();
-        float scaled = 1.2f - (baseTemp * 0.6f);
-        return Mth.clamp(scaled, 0.55f, 1.2f);
+        float tempCelsius = ClientTemperatureResolver.getCelsius(level, pos);
+        // Map the PA temperature range (roughly -20°C → 35°C) to a brightness boost.
+        // Colder environments yield brighter auroras while warmer biomes dim them.
+        float normalized = (15.0f - tempCelsius) / 20.0f;
+        float scaled = 0.6f + Mth.clamp(normalized, 0.0f, 1.0f) * 0.75f;
+        return Mth.clamp(scaled, 0.45f, 1.35f);
     }
 
     public static float combinedBoost(Level level, BlockPos pos) {

--- a/src/main/java/net/Gabou/projectatmosphere/compat/rainbows/RainbowRainBridge.java
+++ b/src/main/java/net/Gabou/projectatmosphere/compat/rainbows/RainbowRainBridge.java
@@ -1,0 +1,73 @@
+package net.Gabou.projectatmosphere.compat.rainbows;
+
+import dev.nonamecrackers2.simpleclouds.common.cloud.region.CloudRegion;
+import dev.nonamecrackers2.simpleclouds.common.cloud.spawning.CloudGenerator;
+import net.Gabou.projectatmosphere.modules.core.CloudLibrary;
+import net.Gabou.projectatmosphere.network.NetworkHandler;
+import net.Gabou.projectatmosphere.network.RainfallUpdatePacket;
+import net.Gabou.projectatmosphere.util.WeatherType;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.network.PacketDistributor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class RainbowRainBridge {
+
+    private static final Map<ResourceKey<Level>, Float> LAST_LEVELS = new HashMap<>();
+    private static final float EPSILON = 0.02f;
+
+    private RainbowRainBridge() {
+    }
+
+    public static void sync(ServerLevel level, CloudGenerator generator) {
+        float rainLevel = computeRainLevel(generator);
+        ResourceKey<Level> dimension = level.dimension();
+        Float previous = LAST_LEVELS.get(dimension);
+        if (previous != null && Math.abs(previous - rainLevel) <= EPSILON) {
+            return;
+        }
+        LAST_LEVELS.put(dimension, rainLevel);
+        RainfallUpdatePacket packet = new RainfallUpdatePacket(dimension.location(), rainLevel);
+        NetworkHandler.CHANNEL.send(PacketDistributor.DIMENSION.with(() -> dimension), packet);
+    }
+
+    public static void clear(ResourceKey<Level> dimension) {
+        LAST_LEVELS.remove(dimension);
+    }
+
+    public static void sendSnapshot(ServerPlayer player, ServerLevel level, CloudGenerator generator) {
+        ResourceKey<Level> dimension = level.dimension();
+        float rainLevel = LAST_LEVELS.getOrDefault(dimension, computeRainLevel(generator));
+        LAST_LEVELS.put(dimension, rainLevel);
+        RainfallUpdatePacket packet = new RainfallUpdatePacket(dimension.location(), rainLevel);
+        NetworkHandler.CHANNEL.send(PacketDistributor.PLAYER.with(() -> player), packet);
+    }
+
+    private static float computeRainLevel(CloudGenerator generator) {
+        List<CloudRegion> clouds = generator.getClouds();
+        if (clouds.isEmpty()) {
+            return 0.0f;
+        }
+        float total = 0.0f;
+        int rainyCount = 0;
+        for (CloudRegion region : clouds) {
+            ResourceLocation type = region.getCloudTypeId();
+            if (WeatherType.isRainy(type)) {
+                rainyCount++;
+                int severity = CloudLibrary.getSeverityFromRessourceLocation(type);
+                total += Math.max(1, severity) / 7.0f;
+            }
+        }
+        if (rainyCount == 0) {
+            return 0.0f;
+        }
+        return Mth.clamp(total / rainyCount, 0.0f, 1.0f);
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/compat/rainbows/RainbowWeatherTracker.java
+++ b/src/main/java/net/Gabou/projectatmosphere/compat/rainbows/RainbowWeatherTracker.java
@@ -5,6 +5,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -49,8 +50,11 @@ public final class RainbowWeatherTracker {
         ClientLevel level = minecraft.level;
         ResourceKey<Level> dimension = level.dimension();
         TrackerState state = STATES.computeIfAbsent(dimension, key -> new TrackerState());
-        boolean raining = isRainingAt(level, minecraft.player.blockPosition());
-        state.update(raining);
+        if (!state.isServerAuthoritative()) {
+            boolean raining = isRainingAt(level, minecraft.player.blockPosition());
+            state.applyFallback(raining);
+        }
+        state.step();
     }
 
     private static boolean isRainingAt(ClientLevel level, BlockPos pos) {
@@ -71,21 +75,52 @@ public final class RainbowWeatherTracker {
         return state != null && state.consumeStopFlag();
     }
 
+    public static void applyServerUpdate(ResourceKey<Level> dimension, float rainLevel) {
+        if (!enabled) {
+            return;
+        }
+        TrackerState state = STATES.computeIfAbsent(dimension, key -> new TrackerState());
+        state.setServerTarget(rainLevel);
+    }
+
     private static final class TrackerState {
-        private boolean wasRaining;
+        private static final float STEP = 0.05f;
+
+        private float target;
         private float rainVisual;
         private boolean stopFlag;
+        private boolean serverAuthoritative;
+        private boolean wasTargetRaining;
 
-        void update(boolean raining) {
-            if (wasRaining && !raining) {
+        void setServerTarget(float value) {
+            serverAuthoritative = true;
+            applyTarget(value);
+        }
+
+        void applyFallback(boolean raining) {
+            if (serverAuthoritative) {
+                return;
+            }
+            applyTarget(raining ? 1.0f : 0.0f);
+        }
+
+        private void applyTarget(float value) {
+            float clamped = Mth.clamp(value, 0.0f, 1.0f);
+            if (Math.abs(clamped - target) <= 0.0005f) {
+                return;
+            }
+            boolean newRaining = clamped > 0.01f;
+            if (wasTargetRaining && !newRaining) {
                 stopFlag = true;
             }
-            wasRaining = raining;
-            float target = raining ? 1.0f : 0.0f;
+            wasTargetRaining = newRaining;
+            target = clamped;
+        }
+
+        void step() {
             float delta = target - rainVisual;
-            float step = 0.05f;
-            if (Math.abs(delta) > step) {
-                rainVisual += Math.copySign(step, delta);
+            if (Math.abs(delta) > STEP) {
+                rainVisual += Math.copySign(STEP, delta);
             } else {
                 rainVisual = target;
             }
@@ -97,6 +132,10 @@ public final class RainbowWeatherTracker {
                 return true;
             }
             return false;
+        }
+
+        boolean isServerAuthoritative() {
+            return serverAuthoritative;
         }
     }
 }

--- a/src/main/java/net/Gabou/projectatmosphere/compat/temperature/ClientTemperatureResolver.java
+++ b/src/main/java/net/Gabou/projectatmosphere/compat/temperature/ClientTemperatureResolver.java
@@ -1,0 +1,35 @@
+package net.Gabou.projectatmosphere.compat.temperature;
+
+import net.Gabou.projectatmosphere.client.BiomeClientTemperatureCache;
+import net.Gabou.projectatmosphere.compat.CompatHandler;
+import net.Gabou.projectatmosphere.compat.ColdSweatCompat;
+import net.Gabou.projectatmosphere.compat.LegendarySurvivalCompat;
+import net.Gabou.projectatmosphere.compat.ToughAsNailsCompat;
+import net.Gabou.projectatmosphere.util.AtmosphereUtils;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+@OnlyIn(Dist.CLIENT)
+public final class ClientTemperatureResolver {
+
+    private ClientTemperatureResolver() {
+    }
+
+    public static float getCelsius(Level level, BlockPos pos) {
+        if (level == null || pos == null) {
+            return 10.0f;
+        }
+        return switch (CompatHandler.getActiveTemperatureMod()) {
+            case LEGENDARY_SURVIVAL -> LegendarySurvivalCompat.getLiveTemperature(level, pos);
+            case TOUGH_AS_NAILS -> ToughAsNailsCompat.getLiveTemperatureTAN(level, pos);
+            case COLD_SWEAT -> ColdSweatCompat.getLiveTemperatureColdSweat(level, pos);
+            default -> {
+                ResourceLocation biome = AtmosphereUtils.getBiomeLocation(pos, level);
+                yield BiomeClientTemperatureCache.getTemperature(biome, level);
+            }
+        };
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/event/EventHandler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/event/EventHandler.java
@@ -6,14 +6,18 @@ import dev.nonamecrackers2.simpleclouds.common.world.CloudManager;
 import dev.nonamecrackers2.simpleclouds.common.world.ServerCloudManager;
 import net.Gabou.projectatmosphere.ProjectAtmosphere;
 import net.Gabou.projectatmosphere.blocks.BlockManager;
+import net.Gabou.projectatmosphere.compat.CompatHandler;
+import net.Gabou.projectatmosphere.compat.rainbows.RainbowRainBridge;
 import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
 import net.Gabou.projectatmosphere.manager.AtmosphereManager;
 import net.Gabou.projectatmosphere.manager.SimpleCloudSpawner;
 import net.Gabou.projectatmosphere.modules.core.CloudLibrary;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -49,6 +53,10 @@ public class EventHandler {
             SimpleCloudSpawner.trySpawnClouds(serverLevel, generator);
         }
 
+        if (CompatHandler.isRainbowsLoaded()) {
+            RainbowRainBridge.sync(serverLevel, generator);
+        }
+
 
         if (!AtmoCommonConfig.ENABLE_STORM_DEBRIS.get()) {
             return;
@@ -68,6 +76,18 @@ public class EventHandler {
         }
 
         tickCounter++;
+    }
+
+    @SubscribeEvent
+    public static void onPlayerChangedDimension(PlayerEvent.PlayerChangedDimensionEvent event) {
+        if (!(event.getEntity() instanceof ServerPlayer player)) {
+            return;
+        }
+        ServerLevel level = player.serverLevel();
+        if (CompatHandler.isRainbowsLoaded() && level.dimension().equals(event.getTo())) {
+            ServerCloudManager cloudManager = (ServerCloudManager) CloudManager.get(level);
+            RainbowRainBridge.sendSnapshot(player, level, cloudManager.getCloudGenerator());
+        }
     }
 
     public static void onRegenerate() {

--- a/src/main/java/net/Gabou/projectatmosphere/manager/AtmosphereManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/manager/AtmosphereManager.java
@@ -4,9 +4,12 @@ package net.Gabou.projectatmosphere.manager;
 import com.Gabou.sereneseasonsplus.api.SSPApi;
 import dev.nonamecrackers2.simpleclouds.common.cloud.region.CloudRegion;
 import dev.nonamecrackers2.simpleclouds.common.world.CloudManager;
+import dev.nonamecrackers2.simpleclouds.common.world.ServerCloudManager;
 import net.Gabou.projectatmosphere.ProjectAtmosphere;
 import net.Gabou.projectatmosphere.command.DebugAtmoCommand;
 import net.Gabou.projectatmosphere.command.SpawnCloudCommand;
+import net.Gabou.projectatmosphere.compat.CompatHandler;
+import net.Gabou.projectatmosphere.compat.rainbows.RainbowRainBridge;
 import net.Gabou.projectatmosphere.event.EventHandler;
 import net.Gabou.projectatmosphere.gameplay.WindPhysics;
 import net.Gabou.projectatmosphere.modules.humidity.HumidityCommand;
@@ -98,6 +101,10 @@ public class AtmosphereManager {
 
         world.getServer().execute(() -> {
             ForecastOrchestrator.onPlayerLogin(player, world);
+            if (CompatHandler.isRainbowsLoaded()) {
+                ServerCloudManager cloudManager = (ServerCloudManager) CloudManager.get(world);
+                RainbowRainBridge.sendSnapshot(player, world, cloudManager.getCloudGenerator());
+            }
             future.complete(null);
         });
     }
@@ -121,6 +128,9 @@ public class AtmosphereManager {
 
     public static void onRegenerate(ServerLevel world) {
         ProjectAtmosphere.LOGGER.info("Regenerating weather data for all players");
+        if (CompatHandler.isRainbowsLoaded()) {
+            RainbowRainBridge.clear(world.dimension());
+        }
         AsyncAtmosphereService.runWeather(() -> {
             EventHandler.onRegenerate();
             CloudManager.get(world).getCloudGenerator().removeAllClouds();

--- a/src/main/java/net/Gabou/projectatmosphere/network/NetworkHandler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/network/NetworkHandler.java
@@ -34,6 +34,11 @@ public class NetworkHandler {
                 .encoder(BiomeDayTemperaturePacket::encode)
                 .consumerMainThread(BiomeDayTemperaturePacket::handle)
                 .add();
+        CHANNEL.messageBuilder(RainfallUpdatePacket.class, id++, NetworkDirection.PLAY_TO_CLIENT)
+                .decoder(RainfallUpdatePacket::decode)
+                .encoder(RainfallUpdatePacket::encode)
+                .consumerMainThread(RainfallUpdatePacket::handle)
+                .add();
 
 
     }

--- a/src/main/java/net/Gabou/projectatmosphere/network/RainfallUpdatePacket.java
+++ b/src/main/java/net/Gabou/projectatmosphere/network/RainfallUpdatePacket.java
@@ -1,0 +1,41 @@
+package net.Gabou.projectatmosphere.network;
+
+import net.Gabou.projectatmosphere.client.ClientPacketHandlers;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public class RainfallUpdatePacket {
+    private final ResourceLocation dimensionId;
+    private final float rainLevel;
+
+    public RainfallUpdatePacket(ResourceLocation dimensionId, float rainLevel) {
+        this.dimensionId = dimensionId;
+        this.rainLevel = rainLevel;
+    }
+
+    public RainfallUpdatePacket(FriendlyByteBuf buf) {
+        this.dimensionId = buf.readResourceLocation();
+        this.rainLevel = buf.readFloat();
+    }
+
+    public void encode(FriendlyByteBuf buf) {
+        buf.writeResourceLocation(dimensionId);
+        buf.writeFloat(rainLevel);
+    }
+
+    public static RainfallUpdatePacket decode(FriendlyByteBuf buf) {
+        return new RainfallUpdatePacket(buf);
+    }
+
+    public static void handle(RainfallUpdatePacket msg, Supplier<NetworkEvent.Context> ctx) {
+        NetworkEvent.Context context = ctx.get();
+        context.enqueueWork(() -> DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () ->
+                ClientPacketHandlers.handleRainfallUpdate(msg.dimensionId, msg.rainLevel)));
+        context.setPacketHandled(true);
+    }
+}


### PR DESCRIPTION
## Summary
- use Project Atmosphere's temperature resolver to scale aurora brightness
- broadcast SimpleClouds rainfall intensity to clients and drive the rainbow tracker from the server
- send rainfall snapshots on login/dimension change and document the fixes in CHANGES.md

## Testing
- gradle build *(fails: apiKey not set for project 1258344)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69115a8d5c588331b64b30eb164cedb1)