### PR TITLE
Slow SimpleClouds thickness evolution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
 # Project Atmosphere — Developer Change Log
 This file records functionality additions/removals made during development sessions, annotated with the current version from `gradle.properties` at the time of change.
 
+## 0.5.5.7 – Cloud persistence tuning (2025-11-13)
+- Clouds now ease toward a humidity-driven target thickness instead of jumping immediately, so growth and dissipation happen over minutes rather than seconds.
+- Dissipation speed scales with biome dryness, letting humid areas keep their systems intact while extreme deserts still erode storms after several minutes of exposure.
+- Rain intensity ramps in slowly alongside thickness, preventing sudden downpours when a cloud first spawns.
+
+## 0.5.5.7 – Cloud spawn throttling (2025-11-12)
+- Added a respawn cooldown to the atmospheric cloud manager so SimpleClouds visuals are not re-created every tick when humidity rapidly crosses the storm threshold.
+- Cloud data now persists through dissipation cycles and only attempts a new spawn once the cooldown elapses, preventing runaway "cloud rave" behaviour.
+
 ## 0.5.5.7 – Storm factor integration (2025-11-11)
 - Removed the legacy storm chance forecast data in favour of live storm factors so gusts, cloud spawners, and SimpleClouds hooks follow the new cyclone/sunlight-driven core.
 - Wind gust multipliers now scale smoothly with the measured storm factor instead of toggling at a fixed threshold.

--- a/src/main/java/net/Gabou/projectatmosphere/modules/atmosphere/CloudManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/atmosphere/CloudManager.java
@@ -12,6 +12,15 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public final class CloudManager {
     private static final Map<BiomeInstanceKey, CloudData> CLOUDS = new ConcurrentHashMap<>();
+    private static final int RESPAWN_COOLDOWN_TICKS = 20 * 10; // 10 seconds
+    private static final float HUMIDITY_SPAWN_THRESHOLD = 0.82f;
+    private static final float THICKNESS_MIN_HUMIDITY = 0.72f;
+    private static final float THICKNESS_MAX_HUMIDITY = 0.95f;
+    private static final float THICKNESS_GROWTH_RATE = 0.0003f;
+    private static final float THICKNESS_BASE_DECAY_RATE = 0.00002f;
+    private static final float THICKNESS_EXTREME_DECAY_RATE = 0.00013f;
+    private static final float RAIN_RAMP_HUMIDITY = HUMIDITY_SPAWN_THRESHOLD + 0.05f;
+    private static final float RAIN_CHANGE_RATE = 0.0025f;
 
     private CloudManager() {
     }
@@ -30,52 +39,61 @@ public final class CloudManager {
             CloudData data = CLOUDS.get(key);
             float humidity = state.getHumidity();
 
-            if (humidity > 0.8f) {
-                if (data == null) {
-                    data = new CloudData();
-                    CLOUDS.put(key, data);
-                    spawnVisual(level, state, data);
-                }
-                data.ticksAlive++;
-                data.thickness = Mth.clamp(data.thickness + 0.01f * (humidity - 0.75f), 0f, 1f);
-            } else if (data != null) {
-                data.ticksAlive++;
-                data.thickness = Math.max(0f, data.thickness - 0.02f);
-                if (data.thickness <= 0.05f) {
-                    CLOUDS.remove(key);
-                    state.setCloudCover(0f);
-                    state.setRainIntensity(0f);
-                    continue;
+            if (data == null && humidity >= HUMIDITY_SPAWN_THRESHOLD) {
+                data = new CloudData();
+                CLOUDS.put(key, data);
+            }
+
+            if (data == null) {
+                state.setCloudCover(Math.max(0f, state.getCloudCover() - 0.01f));
+                state.setRainIntensity(Math.max(0f, state.getRainIntensity() - 0.01f));
+                continue;
+            }
+
+            data.tickCooldown();
+            data.ticksAlive++;
+            data.updateThickness(humidity);
+
+            if (humidity >= HUMIDITY_SPAWN_THRESHOLD && !data.spawnedVisual && data.canSpawn()) {
+                if (spawnVisual(level, state)) {
+                    data.spawnedVisual = true;
+                    data.ticksAlive = 0;
                 }
             }
 
-            if (data != null) {
-                if (data.ticksAlive > 200 && humidity > 0.85f) {
-                    float rain = Mth.clamp((humidity - 0.75f) * 2f, 0f, 1f);
-                    data.rainIntensity = Math.max(data.rainIntensity, rain);
-                } else {
-                    data.rainIntensity = Math.max(0f, data.rainIntensity - 0.02f);
-                }
-                state.setCloudCover(data.thickness);
-                state.setRainIntensity(data.rainIntensity);
-            } else {
-                state.setCloudCover(Math.max(0f, state.getCloudCover() - 0.015f));
-                state.setRainIntensity(0f);
+            if (data.spawnedVisual && data.thickness <= 0.06f && humidity < HUMIDITY_SPAWN_THRESHOLD) {
+                data.spawnedVisual = false;
+                data.resetCooldown();
             }
+
+            if (!data.spawnedVisual && data.canSpawn() && data.thickness <= 0.01f && humidity < HUMIDITY_SPAWN_THRESHOLD - 0.04f) {
+                CLOUDS.remove(key);
+                state.setCloudCover(0f);
+                state.setRainIntensity(0f);
+                continue;
+            }
+
+            if (data.spawnedVisual) {
+                data.updateRainIntensity(humidity);
+            } else {
+                data.rainIntensity = Math.max(0f, data.rainIntensity - RAIN_CHANGE_RATE);
+            }
+
+            state.setCloudCover(data.thickness);
+            state.setRainIntensity(data.rainIntensity);
         }
     }
 
-    private static void spawnVisual(ServerLevel level, RegionAtmosphereState state, CloudData data) {
-        if (data.spawnedVisual || !SimpleCloudsCompat.getIsInit()) {
-            return;
+    private static boolean spawnVisual(ServerLevel level, RegionAtmosphereState state) {
+        if (!SimpleCloudsCompat.getIsInit()) {
+            return false;
         }
         String cloudId = CloudLibrary.getCloudIdFromSeverity(Mth.clamp(Math.round(state.getHumidity() * 7f), 1, 7));
         WindVector wind = state.getWind();
         if (wind == null) {
             wind = WindVector.fromBase(1f, 0f);
         }
-        SimpleCloudsCompat.spawnCloudInBiome(cloudId, state.getKey(), level, null, wind);
-        data.spawnedVisual = true;
+        return SimpleCloudsCompat.spawnCloudInBiome(cloudId, state.getKey(), level, null, wind) != null;
     }
 
     private static final class CloudData {
@@ -83,5 +101,50 @@ public final class CloudManager {
         private long ticksAlive;
         private float rainIntensity;
         private boolean spawnedVisual;
+        private int respawnCooldown;
+
+        private void updateThickness(float humidity) {
+            float target = (humidity - THICKNESS_MIN_HUMIDITY) / (THICKNESS_MAX_HUMIDITY - THICKNESS_MIN_HUMIDITY);
+            target = Mth.clamp(target, 0f, 1f);
+            float delta = target - thickness;
+
+            if (delta > 0f) {
+                float increase = Math.min(delta, THICKNESS_GROWTH_RATE);
+                thickness = Mth.clamp(thickness + increase, 0f, 1f);
+            } else if (delta < 0f) {
+                float dryness = Mth.clamp((HUMIDITY_SPAWN_THRESHOLD - humidity) / HUMIDITY_SPAWN_THRESHOLD, 0f, 1f);
+                float maxLoss = THICKNESS_BASE_DECAY_RATE + dryness * THICKNESS_EXTREME_DECAY_RATE;
+                float decrease = Math.max(delta, -maxLoss);
+                thickness = Mth.clamp(thickness + decrease, 0f, 1f);
+            }
+        }
+
+        private void updateRainIntensity(float humidity) {
+            float desiredRain = 0f;
+            if (humidity >= RAIN_RAMP_HUMIDITY && thickness > 0.4f) {
+                float humidityFactor = (humidity - RAIN_RAMP_HUMIDITY) / (1f - RAIN_RAMP_HUMIDITY);
+                desiredRain = Mth.clamp(humidityFactor, 0f, 1f) * thickness;
+            }
+
+            if (desiredRain > rainIntensity) {
+                rainIntensity = Math.min(desiredRain, rainIntensity + RAIN_CHANGE_RATE);
+            } else {
+                rainIntensity = Math.max(desiredRain, rainIntensity - RAIN_CHANGE_RATE * 0.5f);
+            }
+        }
+
+        private void tickCooldown() {
+            if (respawnCooldown > 0) {
+                respawnCooldown--;
+            }
+        }
+
+        private void resetCooldown() {
+            respawnCooldown = RESPAWN_COOLDOWN_TICKS;
+        }
+
+        private boolean canSpawn() {
+            return respawnCooldown <= 0;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- smooth SimpleClouds thickness growth and dissipation by moving toward a humidity-based target and scaling decay with biome dryness
- ramp rain intensity in gradually so new spawns do not produce instant downpours
- document the cloud persistence tuning in CHANGES.md

## Testing
- gradle build *(fails: JDK 17 toolchain not available in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69129bf4ff648331b3341d78599bbce5)