### PR TITLE
Refactor wind system into layered models

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,12 @@ This file records functionality additions/removals made during development sessi
 - In-game config screen adds an “Imperial Units” toggle under Display.
 - Regeneration safety: clearing/regenerating forecasts now pauses dependent ticks (wind physics, tornado/hurricane/snowstorm managers), and defers scheduled tornado checks until regeneration completes.
 
+## Unreleased — Unified wind stack
+- Rebuilt wind handling into a high/low layer model with gust-aware forecasts and runtime smoothing that mirrors the other environment modules.
+- Added tornado-aware low wind forces plus helpers to apply combined wind, gust, and suction/rotation/lift to players.
+- Wired SimpleClouds and forecast orchestration to consume the new wind API while preserving existing forecast generation inputs.
+- Ground-level wind particles near players now receive directional pushes when the airflow is unobstructed, keeping leaves and streaks aligned with live wind samples.
+
 ## 0.5.4.4 — Added weatherdebug cloud command (2025-10-17)
 - Added command: `/weatherdebug cloud <id>`
   - Spawns the specified SimpleClouds cloud at the player’s position/biome.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Project Atmosphere — Developer Change Log
 This file records functionality additions/removals made during development sessions, annotated with the current version from `gradle.properties` at the time of change.
+
+## Unreleased – Biome naming and TFC coverage
+- `BiomeTempConfig` now warns when biome keys are provided without a namespace (e.g., `minecraft:desert`, `biomesoplenty:bayou`) so config stays tied to the right mod IDs.
+- Added TerraFirmaCraft main and technical biome temperature curves (oceans, plains, mountains, rivers, beaches, edges, and estuaries) to keep climate sampling consistent in modded worlds.
+
 ## 0.6.0.0-pre3 - Sky effects + season bridge (2025-11-24)
 - Tornado shader now binds live SimpleClouds cloud color as its base texture (fallback to static) and densifies alpha/color to remove moving holes; `/spawnTornado` no longer blocks when `CloudTornadoes` SSBO is missing (spawns shader funnel unless legacy fallback is explicitly enabled).
 - Added a pluggable season time helper (neutral default) and refactored client season consumers (auroras, leaves, hurricanes, temperature generation) to rely on it instead of Serene Seasons directly.

--- a/src/main/java/net/Gabou/projectatmosphere/api/WindVectorApi.java
+++ b/src/main/java/net/Gabou/projectatmosphere/api/WindVectorApi.java
@@ -1,5 +1,6 @@
 package net.Gabou.projectatmosphere.api;
 
+import net.Gabou.projectatmosphere.modules.wind.WindEngine;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
 import net.minecraft.server.level.ServerLevel;
 
@@ -9,9 +10,8 @@ public final class WindVectorApi {
     public record WindSample(float speedMps, float directionDeg) {}
 
     public static WindSample getSurface(BiomeInstanceKey key) {
-        net.Gabou.projectatmosphere.modules.core.WindVector.WindSample w =
-                net.Gabou.projectatmosphere.modules.core.WindVector.getOrFallback(key);
-        return new WindSample(w.speedMps(), w.directionDeg());
+        var vector = WindEngine.getCurrentLowWindVector(key, 0L);
+        return new WindSample(vector.baseSpeed(), (float) Math.toDegrees(vector.angleRadians()));
     }
 
     public static WindSample getOrFallback(BiomeInstanceKey key) {
@@ -19,9 +19,9 @@ public final class WindVectorApi {
     }
 
     public static WindSample getAloftProxy(BiomeInstanceKey key, ServerLevel level) {
-        WindSample surface = getSurface(key);
-        float dir = surface.directionDeg() + (level.random.nextFloat() * 20f - 10f);
-        float speed = surface.speedMps() + 5f;
+        var vector = WindEngine.getCurrentHighWindVector(key, level.getGameTime());
+        float dir = (float) Math.toDegrees(vector.angleRadians());
+        float speed = vector.baseSpeed();
         return new WindSample(speed, dir);
     }
 }

--- a/src/main/java/net/Gabou/projectatmosphere/event/SimpleCloudsEventListener.java
+++ b/src/main/java/net/Gabou/projectatmosphere/event/SimpleCloudsEventListener.java
@@ -11,6 +11,7 @@ import net.Gabou.projectatmosphere.compat.SimpleCloudsCompat;
 import net.Gabou.projectatmosphere.manager.AtmosphereManager;
 import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
 import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.Gabou.projectatmosphere.modules.wind.WindEngine;
 import net.Gabou.projectatmosphere.modules.tornado.TornadoManager;
 import net.Gabou.projectatmosphere.util.AtmosphereUtils;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
@@ -54,10 +55,9 @@ public class SimpleCloudsEventListener {
         int y = serverLevel.getSeaLevel();
 
         BiomeInstanceKey key = AtmosphereUtils.getBiomeKey(serverLevel, new BlockPos(x, y, z));
-        // Current sample (fallback-safe) for direction preservation
-        var current = WindVector.getOrFallback(key);
-        float currentSpeed = current.speedMps();
-        float dirDeg = current.directionDeg();
+        WindVector current = WindEngine.getCurrentHighWindVector(key, serverLevel.getGameTime());
+        float currentSpeed = current.baseSpeed();
+        float dirDeg = (float) Math.toDegrees(current.angleRadians());
 
         // Storm-based boost
         float stormFactor = ForecastOrchestrator.getCurrentStormChance(key, serverLevel.getGameTime());

--- a/src/main/java/net/Gabou/projectatmosphere/gameplay/WindPhysics.java
+++ b/src/main/java/net/Gabou/projectatmosphere/gameplay/WindPhysics.java
@@ -1,39 +1,16 @@
 package net.Gabou.projectatmosphere.gameplay;
 
-import net.Gabou.projectatmosphere.modules.core.WindVector;
-import net.Gabou.projectatmosphere.util.AtmosphereUtils;
-import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
-import net.Gabou.projectatmosphere.modules.wind.WindConfig;
+import net.Gabou.projectatmosphere.modules.wind.WindForces;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.phys.Vec3;
 
 public final class WindPhysics {
     private WindPhysics() { }
 
     public static void onServerTick(ServerLevel level) {
         for (ServerPlayer p : level.players()) {
-            applyIfStrong(level, p);
+            WindForces.applyToPlayer(level, p, 1.0f);
         }
-    }
-
-    private static void applyIfStrong(ServerLevel lvl, LivingEntity e) {
-        BiomeInstanceKey key = AtmosphereUtils.getBiomeKey(lvl, e.blockPosition());
-        WindVector.WindSample w = WindVector.getOrFallback(key);
-        if (w.speedMps() < WindConfig.pushThresholdMps()) return;
-        Vec3 push = dirToVec(w.directionDeg()).scale(w.speedMps() * pushScale(e));
-        e.push(push.x, 0.0, push.z);
-        e.hurtMarked = true;
-    }
-
-    private static Vec3 dirToVec(float deg) {
-        double rad = Math.toRadians(deg);
-        return new Vec3(-Math.sin(rad), 0.0, Math.cos(rad));
-    }
-
-    private static double pushScale(LivingEntity e) {
-        return e instanceof ServerPlayer ? WindConfig.playerPushScale() : WindConfig.entityPushScale();
     }
 }
 

--- a/src/main/java/net/Gabou/projectatmosphere/manager/ForecastOrchestrator.java
+++ b/src/main/java/net/Gabou/projectatmosphere/manager/ForecastOrchestrator.java
@@ -9,7 +9,6 @@ import net.Gabou.projectatmosphere.modules.atmosphere.CycloneManager;
 import net.Gabou.projectatmosphere.modules.atmosphere.RainSystem;
 import net.Gabou.projectatmosphere.modules.atmosphere.SunlightController;
 import net.Gabou.projectatmosphere.modules.core.BiomeForecast;
-import net.Gabou.projectatmosphere.modules.core.WindVector;
 import net.Gabou.projectatmosphere.modules.ocean.OceanBasinManager;
 import net.Gabou.projectatmosphere.modules.tornado.GlassDamageManager;
 import net.Gabou.projectatmosphere.util.AsyncAtmosphereService;
@@ -20,10 +19,7 @@ import net.Gabou.projectatmosphere.modules.tornado.TornadoProbabilityManager;
 import net.Gabou.projectatmosphere.modules.hurricane.HurricaneManager;
 import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
 
-import net.Gabou.projectatmosphere.modules.wind.FloatRange;
 import net.Gabou.projectatmosphere.modules.wind.WindEngine;
-import net.Gabou.projectatmosphere.modules.wind.WindForecast;
-import net.Gabou.projectatmosphere.modules.wind.WindForecastPart;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
@@ -73,6 +69,7 @@ public class ForecastOrchestrator {
         if (ForecastDataStorage.hasCenterData() && ForecastDataStorage.hasForecastData()) {
             try {
                 ForecastGenerator.generateForecastForSavedRegion(level);
+                WindEngine.rebuildFromForecasts(ForecastGenerator.getForecastMap());
                 initializeDynamicSystems(level);
                 return true;
             } catch (Exception e) {
@@ -81,6 +78,7 @@ public class ForecastOrchestrator {
                 ForecastDataStorage.clearAll(level);
                 ForecastGenerator.clearForecasts();
                 ForecastGenerator.generateForecastForRegion(level.getSharedSpawnPos(), level);
+                WindEngine.rebuildFromForecasts(ForecastGenerator.getForecastMap());
                 initializeDynamicSystems(level);
                 return true;
             }
@@ -94,7 +92,7 @@ public class ForecastOrchestrator {
         } else {
             ForecastGenerator.generateForecastForRegion(level.getSharedSpawnPos(), level);
         }
-
+        WindEngine.rebuildFromForecasts(ForecastGenerator.getForecastMap());
         initializeDynamicSystems(level);
         return true;
     }
@@ -179,8 +177,8 @@ public class ForecastOrchestrator {
 
             ForecastGenerator.getForecastMap().forEach((key, forecast) -> {
                 AtmosphericStateRegistry.initializeState(key, forecast);
-                generateWindForecast(key, forecast);
             });
+            WindEngine.rebuildFromForecasts(ForecastGenerator.getForecastMap());
             initializeDynamicSystems(level);
         } finally {
             REGENERATING = false;
@@ -201,8 +199,8 @@ public class ForecastOrchestrator {
             ForecastGenerator.generateForecastForRegion(spawn, level);
             ForecastGenerator.getForecastMap().forEach((key, forecast) -> {
                 AtmosphericStateRegistry.initializeState(key, forecast);
-                generateWindForecast(key, forecast);
             });
+            WindEngine.rebuildFromForecasts(ForecastGenerator.getForecastMap());
             initializeDynamicSystems(level);
             return;
         }
@@ -217,10 +215,8 @@ public class ForecastOrchestrator {
      */
     public static void updateForecast(ServerLevel level, BlockPos center) {
         ForecastGenerator.generateForecastForRegion(center, level);
-        ForecastGenerator.getForecastMap().forEach((key, forecast) -> {
-            AtmosphericStateRegistry.initializeState(key, forecast);
-            generateWindForecast(key, forecast);
-        });
+        ForecastGenerator.getForecastMap().forEach((key, forecast) -> AtmosphericStateRegistry.initializeState(key, forecast));
+        WindEngine.rebuildFromForecasts(ForecastGenerator.getForecastMap());
         initializeDynamicSystems(level);
     }
 
@@ -283,6 +279,7 @@ public class ForecastOrchestrator {
         CycloneManager.update(level);
         WindVector.update(level);
         CloudManager.update(level);
+        WindEngine.tick(level, activeKeys);
         RainSystem.update(level);
 
         long now = level.getGameTime();
@@ -342,42 +339,6 @@ public class ForecastOrchestrator {
         CloudManager.initialize(level);
         CycloneManager.initialize(level);
         OceanBasinManager.initialize(level);
-    }
-
-    public static void generateWindForecast(BiomeInstanceKey key, BiomeForecast forecast) {
-        var state = AtmosphericStateRegistry.getState(key);
-        WindVector today = state != null ? state.getWind() : null;
-        if (today == null) {
-            WindVector[] week = forecast.getWind();
-            if (week != null && week.length > 0) {
-                today = week[0];
-            }
-        }
-        if (today == null) {
-            return;
-        }
-
-        float baseMax = today.baseSpeed();
-        float gustMax = today.gustSpeed();
-        float dirDeg = (float) Math.toDegrees(today.angleRadians());
-        float gustProbValue = gustMax > baseMax ? 0.3f : 0f;
-
-        java.util.EnumMap<WindForecastPart, FloatRange> base = new java.util.EnumMap<>(WindForecastPart.class);
-        java.util.EnumMap<WindForecastPart, FloatRange> gust = new java.util.EnumMap<>(WindForecastPart.class);
-        java.util.EnumMap<WindForecastPart, Float> prob = new java.util.EnumMap<>(WindForecastPart.class);
-        java.util.EnumMap<WindForecastPart, FloatRange> dir = new java.util.EnumMap<>(WindForecastPart.class);
-
-        float[] stageScale = {0.3f, 1.0f, 0.8f, 0.6f, 0.4f, 0.2f};
-        WindForecastPart[] parts = WindForecastPart.values();
-        for (int i = 0; i < parts.length; i++) {
-            float scale = stageScale[i];
-            base.put(parts[i], new FloatRange(0f, baseMax * scale));
-            gust.put(parts[i], new FloatRange(0f, gustMax * scale));
-            prob.put(parts[i], gustProbValue);
-            dir.put(parts[i], new FloatRange(dirDeg - 15f, dirDeg + 15f));
-        }
-
-        WindEngine.putForecast(key, new WindForecast(base, gust, prob, dir));
     }
 
 

--- a/src/main/java/net/Gabou/projectatmosphere/modules/temperature/config/BiomeTempConfig.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/temperature/config/BiomeTempConfig.java
@@ -3691,6 +3691,148 @@ public class BiomeTempConfig {
                 new Range(22, 28)
         });
 
+        // TerraFirmaCraft – main biomes
+        putAllSeasons("tfc:ocean", new Range[]{
+                new Range(-2f, 8f),
+                new Range(4f, 14f),
+                new Range(12f, 24f),
+                new Range(6f, 16f)
+        });
+        putAllSeasons("tfc:deep_ocean", new Range[]{
+                new Range(-4f, 6f),
+                new Range(2f, 12f),
+                new Range(10f, 20f),
+                new Range(4f, 14f)
+        });
+        putAllSeasons("tfc:plains", new Range[]{
+                new Range(-6f, 8f),
+                new Range(4f, 18f),
+                new Range(14f, 30f),
+                new Range(6f, 20f)
+        });
+        putAllSeasons("tfc:high_plains", new Range[]{
+                new Range(-10f, 4f),
+                new Range(-2f, 16f),
+                new Range(10f, 26f),
+                new Range(2f, 18f)
+        });
+        putAllSeasons("tfc:swamp", new Range[]{
+                new Range(0f, 12f),
+                new Range(8f, 22f),
+                new Range(16f, 32f),
+                new Range(8f, 22f)
+        });
+        putAllSeasons("tfc:mountains", new Range[]{
+                new Range(-16f, -2f),
+                new Range(-8f, 8f),
+                new Range(2f, 18f),
+                new Range(-6f, 10f)
+        });
+        putAllSeasons("tfc:rolling_hills", new Range[]{
+                new Range(-4f, 10f),
+                new Range(6f, 20f),
+                new Range(14f, 28f),
+                new Range(6f, 20f)
+        });
+        putAllSeasons("tfc:high_hills", new Range[]{
+                new Range(-12f, 2f),
+                new Range(-2f, 14f),
+                new Range(8f, 24f),
+                new Range(-4f, 12f)
+        });
+        putAllSeasons("tfc:mountain_range", new Range[]{
+                new Range(-18f, -4f),
+                new Range(-10f, 6f),
+                new Range(0f, 16f),
+                new Range(-8f, 8f)
+        });
+        putAllSeasons("tfc:salt_swamp", new Range[]{
+                new Range(4f, 16f),
+                new Range(10f, 24f),
+                new Range(18f, 34f),
+                new Range(10f, 24f)
+        });
+        putAllSeasons("tfc:peat_bog", new Range[]{
+                new Range(-6f, 8f),
+                new Range(2f, 18f),
+                new Range(10f, 26f),
+                new Range(2f, 18f)
+        });
+
+        // TerraFirmaCraft – technical biomes
+        putAllSeasons("tfc:river", new Range[]{
+                new Range(-2f, 10f),
+                new Range(6f, 18f),
+                new Range(12f, 26f),
+                new Range(6f, 18f)
+        });
+        putAllSeasons("tfc:beach", new Range[]{
+                new Range(2f, 14f),
+                new Range(8f, 22f),
+                new Range(16f, 30f),
+                new Range(8f, 22f)
+        });
+        putAllSeasons("tfc:gravel_beach", new Range[]{
+                new Range(0f, 12f),
+                new Range(6f, 20f),
+                new Range(14f, 28f),
+                new Range(6f, 20f)
+        });
+        putAllSeasons("tfc:lake", new Range[]{
+                new Range(-2f, 10f),
+                new Range(6f, 18f),
+                new Range(12f, 26f),
+                new Range(6f, 18f)
+        });
+        putAllSeasons("tfc:shore", new Range[]{
+                new Range(2f, 12f),
+                new Range(8f, 20f),
+                new Range(14f, 28f),
+                new Range(8f, 20f)
+        });
+        putAllSeasons("tfc:high_hills_edge", new Range[]{
+                new Range(-8f, 6f),
+                new Range(0f, 16f),
+                new Range(10f, 24f),
+                new Range(-2f, 14f)
+        });
+        putAllSeasons("tfc:mountain_edge", new Range[]{
+                new Range(-10f, 2f),
+                new Range(-2f, 12f),
+                new Range(6f, 20f),
+                new Range(-4f, 10f)
+        });
+        putAllSeasons("tfc:mountain_range_edge", new Range[]{
+                new Range(-14f, 0f),
+                new Range(-6f, 10f),
+                new Range(4f, 18f),
+                new Range(-6f, 8f)
+        });
+        putAllSeasons("tfc:foothills", new Range[]{
+                new Range(-6f, 8f),
+                new Range(2f, 18f),
+                new Range(12f, 26f),
+                new Range(4f, 18f)
+        });
+        putAllSeasons("tfc:lakeshore", new Range[]{
+                new Range(0f, 12f),
+                new Range(8f, 20f),
+                new Range(14f, 28f),
+                new Range(8f, 20f)
+        });
+        putAllSeasons("tfc:riverbank", new Range[]{
+                new Range(-2f, 10f),
+                new Range(6f, 18f),
+                new Range(12f, 26f),
+                new Range(6f, 18f)
+        });
+        putAllSeasons("tfc:estuary", new Range[]{
+                new Range(2f, 14f),
+                new Range(10f, 22f),
+                new Range(16f, 30f),
+                new Range(10f, 22f)
+        });
+
 
 
 
@@ -3774,6 +3916,11 @@ public class BiomeTempConfig {
             }
         }
 
+        ProjectAtmosphere.LOGGER.warn(
+                "Biome key '{}' is missing a namespace; assuming minecraft:{} when unique. " +
+                        "Prefer explicit ids such as minecraft:desert or biomesoplenty:bayou to avoid ambiguity.",
+                biomeKey, biomeKey);
+
         // Default to minecraft namespace first
         ResourceLocation def = ResourceLocation.withDefaultNamespace(biomeKey);
 
@@ -3795,7 +3942,7 @@ public class BiomeTempConfig {
             return Set.of(def);
         }
         if (matches.size() > 1) {
-            ProjectAtmosphere.LOGGER.info("Multiple biomes match path '{}': {}", biomeKey, matches);
+            ProjectAtmosphere.LOGGER.warn("Multiple biomes match path '{}': {} — specify the mod id.", biomeKey, matches);
         }
         return matches;
     }

--- a/src/main/java/net/Gabou/projectatmosphere/modules/wind/HighWindModel.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/wind/HighWindModel.java
@@ -1,0 +1,36 @@
+package net.Gabou.projectatmosphere.modules.wind;
+
+import net.Gabou.projectatmosphere.modules.core.WindVector;
+
+/**
+ * Produces smooth upper-level wind vectors used for cloud motion and visuals.
+ */
+public final class HighWindModel {
+    private HighWindModel() { }
+
+    public static WindVector sample(WindForecast forecast, WindRuntimeState runtime, long worldTime) {
+        WindVector target = forecast.sampleHigh(worldTime);
+        float speed = blend(runtime.getCurrentHighSpeed(), target.baseSpeed());
+        float dirDeg = blendAngle(runtime.getCurrentHighDirectionDeg(), (float) Math.toDegrees(target.angleRadians()));
+
+        runtime.setCurrentHighSpeed(speed);
+        runtime.setCurrentHighDirectionDeg(dirDeg);
+        return new WindVector(speed, (float) Math.toRadians(dirDeg), target.gustSpeed());
+    }
+
+    private static float blend(float current, float target) {
+        return current + (target - current) * 0.1f;
+    }
+
+    private static float blendAngle(float currentDeg, float targetDeg) {
+        float delta = wrapDegrees(targetDeg - currentDeg);
+        return currentDeg + delta * 0.1f;
+    }
+
+    private static float wrapDegrees(float deg) {
+        float wrapped = deg % 360f;
+        if (wrapped <= -180f) wrapped += 360f;
+        if (wrapped > 180f) wrapped -= 360f;
+        return wrapped;
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/modules/wind/LowWindModel.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/wind/LowWindModel.java
@@ -1,0 +1,73 @@
+package net.Gabou.projectatmosphere.modules.wind;
+
+import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.minecraft.util.Mth;
+
+import java.util.Random;
+
+/**
+ * Ground-level wind model that adds gusts and keeps values smooth for player interactions.
+ */
+public final class LowWindModel {
+    private LowWindModel() { }
+
+    public static WindVector sample(WindForecast forecast, WindRuntimeState runtime, long worldTime, float stormChance) {
+        WindVector target = forecast.sampleLow(worldTime);
+        Random rng = new Random(worldTime + Float.floatToIntBits(target.baseSpeed()));
+
+        if (!runtime.isGustActive()) {
+            float chance = forecast.gustProbability();
+            chance += stormChance * forecast.stormGustProbability();
+            if (rng.nextFloat() < chance) {
+                startGust(runtime, target, worldTime, rng, false);
+            } else if (rng.nextFloat() < forecast.spikeProbability()) {
+                startGust(runtime, target, worldTime, rng, true);
+            }
+        } else if (worldTime >= runtime.getGustEndTick()) {
+            runtime.setGustActive(false);
+            runtime.setCurrentGustBonus(0f);
+        }
+
+        if (runtime.isGustActive()) {
+            float decay = runtime.getCurrentGustBonus() * 0.05f;
+            runtime.setCurrentGustBonus(Math.max(0f, runtime.getCurrentGustBonus() - decay));
+            if (runtime.getCurrentGustBonus() <= 0.01f) {
+                runtime.setGustActive(false);
+            }
+        }
+
+        float gustedSpeed = target.baseSpeed() + runtime.getCurrentGustBonus();
+        float smoothedSpeed = blend(runtime.getCurrentLowSpeed(), gustedSpeed);
+        float dirDeg = blendAngle(runtime.getCurrentLowDirectionDeg(), (float) Math.toDegrees(target.angleRadians()));
+
+        runtime.setCurrentLowSpeed(smoothedSpeed);
+        runtime.setCurrentLowDirectionDeg(dirDeg);
+        return new WindVector(smoothedSpeed, (float) Math.toRadians(dirDeg), smoothedSpeed + 0.5f * (target.gustSpeed() - target.baseSpeed()));
+    }
+
+    private static void startGust(WindRuntimeState runtime, WindVector target, long worldTime, Random rng, boolean spike) {
+        float gustHeadroom = Math.max(0f, target.gustSpeed() - target.baseSpeed());
+        float multiplier = spike ? 1.2f : 0.6f + rng.nextFloat() * 0.6f;
+        float gustAmount = gustHeadroom * multiplier;
+        runtime.setCurrentGustBonus(gustAmount);
+        runtime.setGustActive(true);
+        long duration = spike ? 40L + rng.nextInt(40) : 80L + rng.nextInt(120);
+        runtime.setGustEndTick(worldTime + duration);
+    }
+
+    private static float blend(float current, float target) {
+        return current + (target - current) * 0.2f;
+    }
+
+    private static float blendAngle(float currentDeg, float targetDeg) {
+        float delta = wrapDegrees(targetDeg - currentDeg);
+        return currentDeg + delta * 0.2f;
+    }
+
+    private static float wrapDegrees(float deg) {
+        float wrapped = Mth.wrapDegrees(deg);
+        if (wrapped < -180f) wrapped += 360f;
+        if (wrapped > 180f) wrapped -= 360f;
+        return wrapped;
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/modules/wind/TornadoWindModel.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/wind/TornadoWindModel.java
@@ -1,0 +1,52 @@
+package net.Gabou.projectatmosphere.modules.wind;
+
+import net.Gabou.projectatmosphere.modules.tornado.TornadoInstance;
+import net.Gabou.projectatmosphere.modules.tornado.TornadoManager;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.List;
+
+/**
+ * Computes player-facing tornado forces so visuals and physics stay in sync.
+ */
+public final class TornadoWindModel {
+    public record TornadoForces(Vec3 pullVector, Vec3 rotationVector, Vec3 liftVector, TornadoInstance source) { }
+
+    private TornadoWindModel() { }
+
+    public static TornadoForces compute(Vec3 position) {
+        List<TornadoInstance> active = TornadoManager.getActiveTornadoes();
+        TornadoInstance nearest = null;
+        double nearestDistSq = Double.MAX_VALUE;
+        for (TornadoInstance tornado : active) {
+            double distSq = tornado.position.distanceToSqr(position.x, tornado.position.y, position.z);
+            if (distSq < nearestDistSq) {
+                nearest = tornado;
+                nearestDistSq = distSq;
+            }
+        }
+        if (nearest == null) {
+            return null;
+        }
+
+        Vec3 center = nearest.position;
+        double dx = center.x - position.x;
+        double dz = center.z - position.z;
+        double horizontalDist = Math.sqrt(dx * dx + dz * dz);
+        double radius = Math.max(4.0, nearest.getSuctionRadius());
+        if (horizontalDist > radius * 3.0) {
+            return null;
+        }
+
+        double proximity = Math.max(0.0, 1.0 - Math.min(horizontalDist, radius) / radius);
+        Vec3 pull = new Vec3(dx, 0.0, dz).normalize().scale(proximity * 0.08 * nearest.getLevel().getMaxWindSpeed());
+
+        Vec3 swirlDir = horizontalDist > 1e-3 ? new Vec3(-(dz / horizontalDist), 0.0, dx / horizontalDist) : Vec3.ZERO;
+        Vec3 rotation = swirlDir.scale(proximity * proximity * 0.12 * nearest.getLevel().getMaxWindSpeed());
+
+        double liftScale = Math.max(0.0, 1.0 - Math.abs(position.y - center.y) / 40.0);
+        Vec3 lift = new Vec3(0.0, proximity * 0.04 * nearest.getLevel().getMaxWindSpeed() * liftScale, 0.0);
+
+        return new TornadoForces(pull, rotation, lift, nearest);
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/modules/wind/WindEngine.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/wind/WindEngine.java
@@ -1,80 +1,81 @@
 package net.Gabou.projectatmosphere.modules.wind;
 
+import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
+import net.Gabou.projectatmosphere.modules.atmosphere.AtmosphericStateRegistry;
+import net.Gabou.projectatmosphere.modules.atmosphere.RegionAtmosphereState;
+import net.Gabou.projectatmosphere.modules.core.BiomeForecast;
 import net.Gabou.projectatmosphere.modules.core.WindVector;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.phys.Vec3;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
+/**
+ * Central wind orchestrator. Maintains forecasts and runtime states for both high and low wind layers.
+ */
 public final class WindEngine {
     private static final Map<BiomeInstanceKey, WindForecast> FORECASTS = new HashMap<>();
     private static final Map<BiomeInstanceKey, WindRuntimeState> STATES = new HashMap<>();
 
     private WindEngine() { }
 
-    public static void init() {
-        // load storage if needed
+    public static void rebuildFromForecasts(Map<BiomeInstanceKey, BiomeForecast> biomeForecasts) {
+        FORECASTS.clear();
+        biomeForecasts.forEach((key, forecast) -> FORECASTS.put(key, WindForecast.fromBiomeForecast(forecast)));
     }
 
-    public static WindRuntimeState getOrCreateRuntime(BiomeInstanceKey key, ServerLevel level) {
-        return STATES.computeIfAbsent(key, k -> new WindRuntimeState());
-    }
-
-    public static void tick(ServerLevel level) {
-        WindForecastPart part = resolvePart(level);
+    public static void tick(ServerLevel level, Set<BiomeInstanceKey> activeKeys) {
         long now = level.getGameTime();
-        for (Map.Entry<BiomeInstanceKey, WindRuntimeState> entry : STATES.entrySet()) {
-            BiomeInstanceKey key = entry.getKey();
-            WindRuntimeState state = entry.getValue();
+        for (BiomeInstanceKey key : activeKeys) {
             WindForecast forecast = FORECASTS.get(key);
             if (forecast == null) {
-                WindVector.WindSample sample = WindVector.getOrFallback(key);
-                WindVector.set(key, sample.speedMps(), sample.directionDeg());
                 continue;
             }
-            if (state.getNextRetargetTick() <= now) {
-                FloatRange base = forecast.getBaseRanges().get(part);
-                if (base != null) {
-                    state.setTargetBaseSpeed(base.random(new java.util.Random()));
-                }
-                FloatRange dir = forecast.getDirRangesDeg().get(part);
-                if (dir != null) {
-                    state.setTargetDirectionDeg(dir.random(new java.util.Random()));
-                }
-                state.setNextRetargetTick(now + (long) (WindConfig.baseRetargetSec() * 20));
-            }
-            float speed = state.getCurrentBaseSpeed() + (state.getTargetBaseSpeed() - state.getCurrentBaseSpeed()) * 0.1f;
-            state.setCurrentBaseSpeed(speed);
-            float dirCur = state.getCurrentDirectionDeg() + (state.getTargetDirectionDeg() - state.getCurrentDirectionDeg()) * 0.1f;
-            state.setCurrentDirectionDeg(dirCur);
+            WindRuntimeState runtime = STATES.computeIfAbsent(key, k -> new WindRuntimeState());
+            float stormChance = ForecastOrchestrator.getCurrentStormChance(key, now);
 
-            WindGustManager.tick(state, forecast, part, key, level, now);
-            float effective = state.getCurrentBaseSpeed() + state.getCurrentGustSpeed();
-            WindVector.set(key, effective, state.getCurrentDirectionDeg());
+            WindVector high = HighWindModel.sample(forecast, runtime, now);
+            WindVector low = LowWindModel.sample(forecast, runtime, now, stormChance);
+
+            RegionAtmosphereState state = AtmosphericStateRegistry.getState(key);
+            if (state != null) {
+                state.setWind(high);
+            }
+
+            WindVector.WindSample sample = new WindVector.WindSample(Math.max(low.baseSpeed(), low.gustSpeed()),
+                    (float) Math.toDegrees(low.angleRadians()));
+            WindVector.set(key, sample.speedMps(), sample.directionDeg());
         }
     }
 
-    public static WindForecast getForecast(BiomeInstanceKey key) {
-        return FORECASTS.get(key);
+    public static WindVector getCurrentHighWindVector(BiomeInstanceKey key, long worldTime) {
+        WindRuntimeState runtime = STATES.computeIfAbsent(key, k -> new WindRuntimeState());
+        WindForecast forecast = FORECASTS.get(key);
+        if (forecast == null) {
+            return WindVector.fromBase(0f, 0f);
+        }
+        return HighWindModel.sample(forecast, runtime, worldTime);
     }
 
-    public static void putForecast(BiomeInstanceKey key, WindForecast forecast) {
-        FORECASTS.put(key, forecast);
+    public static WindVector getCurrentLowWindVector(BiomeInstanceKey key, long worldTime) {
+        WindRuntimeState runtime = STATES.computeIfAbsent(key, k -> new WindRuntimeState());
+        WindForecast forecast = FORECASTS.get(key);
+        if (forecast == null) {
+            return WindVector.fromBase(0f, 0f);
+        }
+        float stormChance = ForecastOrchestrator.getCurrentStormChance(key, worldTime);
+        return LowWindModel.sample(forecast, runtime, worldTime, stormChance);
     }
 
-    public static WindForecastPart resolvePart(ServerLevel level) {
-        long time = level.getDayTime() % 24000L;
-        if (time < 4000L) return WindForecastPart.MORNING;
-        if (time < 8000L) return WindForecastPart.NOON;
-        if (time < 12000L) return WindForecastPart.AFTERNOON;
-        if (time < 16000L) return WindForecastPart.EVENING;
-        if (time < 20000L) return WindForecastPart.MIDNIGHT;
-        return WindForecastPart.NIGHT;
+    public static boolean isGustActive(BiomeInstanceKey key) {
+        WindRuntimeState runtime = STATES.get(key);
+        return runtime != null && runtime.isGustActive();
     }
 
-    public static void syncToClients(BiomeInstanceKey key, ServerLevel level) {
-        // networking stub
+    public static TornadoWindModel.TornadoForces getCurrentTornadoForce(Vec3 position) {
+        return TornadoWindModel.compute(position);
     }
 }
-

--- a/src/main/java/net/Gabou/projectatmosphere/modules/wind/WindForces.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/wind/WindForces.java
@@ -1,0 +1,44 @@
+package net.Gabou.projectatmosphere.modules.wind;
+
+import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.Gabou.projectatmosphere.util.AtmosphereUtils;
+import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Applies combined low-level wind, gusts, and tornado forces to entities.
+ */
+public final class WindForces {
+    private WindForces() { }
+
+    public static void applyToPlayer(ServerLevel level, ServerPlayer player, float deltaTime) {
+        BiomeInstanceKey key = AtmosphereUtils.getBiomeKey(level, player.blockPosition());
+        WindVector low = WindEngine.getCurrentLowWindVector(key, level.getGameTime());
+        double windMagnitude = Math.max(low.baseSpeed(), low.gustSpeed());
+        if (windMagnitude > WindConfig.pushThresholdMps()) {
+            Vec3 push = dirToVec(low.angleRadians()).scale(windMagnitude * WindConfig.playerPushScale() * deltaTime / 20f);
+            player.push(push.x, 0.0, push.z);
+            player.hurtMarked = true;
+        }
+
+        TornadoWindModel.TornadoForces tornado = WindEngine.getCurrentTornadoForce(player.position());
+        if (tornado != null) {
+            applyTornadoForce(player, tornado, deltaTime);
+        }
+    }
+
+    private static void applyTornadoForce(LivingEntity entity, TornadoWindModel.TornadoForces forces, float deltaTime) {
+        double scale = deltaTime / 20f;
+        Vec3 combined = forces.pullVector().add(forces.rotationVector()).scale(scale);
+        Vec3 lift = forces.liftVector().scale(scale);
+        entity.push(combined.x, lift.y, combined.z);
+        entity.hurtMarked = true;
+    }
+
+    private static Vec3 dirToVec(float rad) {
+        return new Vec3(-Math.sin(rad), 0.0, Math.cos(rad));
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/modules/wind/WindForecast.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/wind/WindForecast.java
@@ -1,37 +1,131 @@
 package net.Gabou.projectatmosphere.modules.wind;
 
-import java.util.EnumMap;
+import net.Gabou.projectatmosphere.modules.core.BiomeForecast;
+import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.minecraft.util.Mth;
 
+/**
+ * Unified wind forecast describing both the upper-level (high) and ground-level (low) wind curves.
+ * The forecast is derived from the weekly {@link BiomeForecast} produced by {@link net.Gabou.projectatmosphere.manager.ForecastGenerator}
+ * without modifying the generator itself.
+ */
 public final class WindForecast {
-    private final EnumMap<WindForecastPart, FloatRange> baseRanges;
-    private final EnumMap<WindForecastPart, FloatRange> gustRanges;
-    private final EnumMap<WindForecastPart, Float> gustProb;
-    private final EnumMap<WindForecastPart, FloatRange> dirRangesDeg;
+    public static final class WindSlice {
+        private final float highBase;
+        private final float highGust;
+        private final float lowBase;
+        private final float lowGust;
+        private final float directionDeg;
 
-    public WindForecast(EnumMap<WindForecastPart, FloatRange> baseRanges,
-                        EnumMap<WindForecastPart, FloatRange> gustRanges,
-                        EnumMap<WindForecastPart, Float> gustProb,
-                        EnumMap<WindForecastPart, FloatRange> dirRangesDeg) {
-        this.baseRanges = baseRanges;
-        this.gustRanges = gustRanges;
-        this.gustProb = gustProb;
-        this.dirRangesDeg = dirRangesDeg;
+        public WindSlice(float highBase, float highGust, float lowBase, float lowGust, float directionDeg) {
+            this.highBase = highBase;
+            this.highGust = highGust;
+            this.lowBase = lowBase;
+            this.lowGust = lowGust;
+            this.directionDeg = directionDeg;
+        }
+
+        public float highBase() {
+            return highBase;
+        }
+
+        public float highGust() {
+            return highGust;
+        }
+
+        public float lowBase() {
+            return lowBase;
+        }
+
+        public float lowGust() {
+            return lowGust;
+        }
+
+        public float directionDeg() {
+            return directionDeg;
+        }
     }
 
-    public EnumMap<WindForecastPart, FloatRange> getBaseRanges() {
-        return baseRanges;
+    private final WindSlice[] slices;
+    private final float gustProbability;
+    private final float stormGustProbability;
+    private final float spikeProbability;
+
+    public WindForecast(WindSlice[] slices, float gustProbability, float stormGustProbability, float spikeProbability) {
+        this.slices = slices;
+        this.gustProbability = gustProbability;
+        this.stormGustProbability = stormGustProbability;
+        this.spikeProbability = spikeProbability;
     }
 
-    public EnumMap<WindForecastPart, FloatRange> getGustRanges() {
-        return gustRanges;
+    public WindSlice sliceForDay(long worldTime) {
+        int day = (int) ((worldTime / 24000L) % slices.length);
+        return slices[Math.max(0, Math.min(day, slices.length - 1))];
     }
 
-    public EnumMap<WindForecastPart, Float> getGustProb() {
-        return gustProb;
+    public float gustProbability() {
+        return gustProbability;
     }
 
-    public EnumMap<WindForecastPart, FloatRange> getDirRangesDeg() {
-        return dirRangesDeg;
+    public float stormGustProbability() {
+        return stormGustProbability;
+    }
+
+    public float spikeProbability() {
+        return spikeProbability;
+    }
+
+    public WindVector sampleHigh(long worldTime) {
+        WindSlice slice = sliceForDay(worldTime);
+        float base = dailyCurve(slice.highBase(), worldTime);
+        float gust = dailyCurve(slice.highGust(), worldTime);
+        float dirRad = (float) Math.toRadians(slice.directionDeg());
+        return new WindVector(base, dirRad, gust);
+    }
+
+    public WindVector sampleLow(long worldTime) {
+        WindSlice slice = sliceForDay(worldTime);
+        float base = dailyCurve(slice.lowBase(), worldTime);
+        float gust = dailyCurve(slice.lowGust(), worldTime);
+        float dirRad = (float) Math.toRadians(slice.directionDeg());
+        return new WindVector(base, dirRad, gust);
+    }
+
+    private static float dailyCurve(float base, long worldTime) {
+        float timeOfDay = (worldTime % 24000L) / 24000f;
+        float wave = (float) Math.sin(timeOfDay * (float) (Math.PI * 2));
+        float dailyScale = 0.8f + 0.2f * wave;
+        return Math.max(0f, base * dailyScale);
+    }
+
+    /**
+     * Creates a unified forecast from the immutable BiomeForecast generated elsewhere.
+     */
+    public static WindForecast fromBiomeForecast(BiomeForecast biomeForecast) {
+        WindVector[] week = biomeForecast.getWind();
+        if (week == null || week.length == 0) {
+            return new WindForecast(new WindSlice[]{new WindSlice(0f, 0f, 0f, 0f, 0f)}, 0f, 0f, 0f);
+        }
+
+        WindSlice[] slices = new WindSlice[week.length];
+        float baseProb = 0.15f;
+        for (int i = 0; i < week.length; i++) {
+            WindVector vector = week[i] == null ? WindVector.fromBase(0f, 0f) : week[i];
+            float baseSpeed = vector.baseSpeed();
+            float gustSpeed = Math.max(vector.gustSpeed(), baseSpeed);
+            float dirDeg = (float) Math.toDegrees(vector.angleRadians());
+
+            float highBase = baseSpeed;
+            float highGust = gustSpeed;
+            float lowBase = baseSpeed * 0.65f;
+            float lowGust = lowBase + (gustSpeed - baseSpeed) * 0.55f;
+
+            slices[i] = new WindSlice(highBase, highGust, lowBase, lowGust, dirDeg);
+            baseProb = Math.max(baseProb, Math.min(0.6f, (gustSpeed - baseSpeed) * 0.02f));
+        }
+
+        float spikeChance = Mth.clamp(baseProb * 0.5f, 0.05f, 0.35f);
+        float stormProb = Mth.clamp(baseProb * 1.5f, baseProb, 0.8f);
+        return new WindForecast(slices, baseProb, stormProb, spikeChance);
     }
 }
-

--- a/src/main/java/net/Gabou/projectatmosphere/modules/wind/WindRuntimeState.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/wind/WindRuntimeState.java
@@ -1,36 +1,60 @@
 package net.Gabou.projectatmosphere.modules.wind;
 
 public final class WindRuntimeState {
-    private float currentBaseSpeed;
-    private float currentGustSpeed;
-    private float currentDirectionDeg;
+    private float currentHighSpeed;
+    private float currentHighDirectionDeg;
+    private float currentLowSpeed;
+    private float currentLowDirectionDeg;
+    private float currentGustBonus;
+    private boolean gustActive;
     private long gustEndTick;
-    private float targetBaseSpeed;
-    private float targetDirectionDeg;
-    private long nextRetargetTick;
 
-    public float getCurrentBaseSpeed() {
-        return currentBaseSpeed;
+    public float getCurrentHighSpeed() {
+        return currentHighSpeed;
     }
 
-    public void setCurrentBaseSpeed(float currentBaseSpeed) {
-        this.currentBaseSpeed = currentBaseSpeed;
+    public void setCurrentHighSpeed(float currentHighSpeed) {
+        this.currentHighSpeed = currentHighSpeed;
     }
 
-    public float getCurrentGustSpeed() {
-        return currentGustSpeed;
+    public float getCurrentHighDirectionDeg() {
+        return currentHighDirectionDeg;
     }
 
-    public void setCurrentGustSpeed(float currentGustSpeed) {
-        this.currentGustSpeed = currentGustSpeed;
+    public void setCurrentHighDirectionDeg(float currentHighDirectionDeg) {
+        this.currentHighDirectionDeg = currentHighDirectionDeg;
     }
 
-    public float getCurrentDirectionDeg() {
-        return currentDirectionDeg;
+    public float getCurrentLowSpeed() {
+        return currentLowSpeed;
     }
 
-    public void setCurrentDirectionDeg(float currentDirectionDeg) {
-        this.currentDirectionDeg = currentDirectionDeg;
+    public void setCurrentLowSpeed(float currentLowSpeed) {
+        this.currentLowSpeed = currentLowSpeed;
+    }
+
+    public float getCurrentLowDirectionDeg() {
+        return currentLowDirectionDeg;
+    }
+
+    public void setCurrentLowDirectionDeg(float currentLowDirectionDeg) {
+        this.currentLowDirectionDeg = currentLowDirectionDeg;
+    }
+
+    public float getCurrentGustBonus() {
+        return currentGustBonus;
+    }
+
+    public void setCurrentGustBonus(float currentGustBonus) {
+        this.currentGustBonus = currentGustBonus;
+    }
+
+    public boolean isGustActive() {
+        return gustActive;
+    }
+
+    public void setGustActive(boolean gustActive) {
+        this.gustActive = gustActive;
     }
 
     public long getGustEndTick() {
@@ -39,30 +63,6 @@ public final class WindRuntimeState {
 
     public void setGustEndTick(long gustEndTick) {
         this.gustEndTick = gustEndTick;
-    }
-
-    public float getTargetBaseSpeed() {
-        return targetBaseSpeed;
-    }
-
-    public void setTargetBaseSpeed(float targetBaseSpeed) {
-        this.targetBaseSpeed = targetBaseSpeed;
-    }
-
-    public float getTargetDirectionDeg() {
-        return targetDirectionDeg;
-    }
-
-    public void setTargetDirectionDeg(float targetDirectionDeg) {
-        this.targetDirectionDeg = targetDirectionDeg;
-    }
-
-    public long getNextRetargetTick() {
-        return nextRetargetTick;
-    }
-
-    public void setNextRetargetTick(long nextRetargetTick) {
-        this.nextRetargetTick = nextRetargetTick;
     }
 }
 

--- a/src/main/java/net/Gabou/projectatmosphere/particles/WindLeafParticle.java
+++ b/src/main/java/net/Gabou/projectatmosphere/particles/WindLeafParticle.java
@@ -4,6 +4,7 @@ import net.Gabou.projectatmosphere.ProjectAtmosphere;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.*;
 import net.minecraft.core.particles.SimpleParticleType;
+import net.minecraft.world.phys.Vec3;
 
 public class WindLeafParticle extends TextureSheetParticle {
 
@@ -47,9 +48,17 @@ public class WindLeafParticle extends TextureSheetParticle {
         } catch (Throwable ignored) {
         }
 
-        
+
+        Vec3 push = WindParticlePusher.computeWindPush(this.level, new Vec3(this.x, this.y, this.z));
+        if (push.lengthSqr() > 0.0) {
+            this.xd += push.x;
+            this.yd += push.y;
+            this.zd += push.z;
+        }
+
+
         this.oRoll = this.roll;
-        this.roll += 0.02f + random.nextFloat() * 0.01f; 
+        this.roll += 0.02f + random.nextFloat() * 0.01f;
 
         
         if (this.age % 5 == 0) {

--- a/src/main/java/net/Gabou/projectatmosphere/particles/WindParticlePusher.java
+++ b/src/main/java/net/Gabou/projectatmosphere/particles/WindParticlePusher.java
@@ -1,0 +1,59 @@
+package net.Gabou.projectatmosphere.particles;
+
+import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
+import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.Gabou.projectatmosphere.util.AtmosphereUtils;
+import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.HitResult;
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Shared helper to nudge ground-level particles in the direction of the current wind.
+ * The push only occurs near players and when there is clear line-of-sight from an upwind
+ * sample position, to avoid wind passing through walls.
+ */
+public final class WindParticlePusher {
+
+    private static final double NEAR_PLAYER_RADIUS = 24.0;
+    private static final double LINE_OF_SIGHT_CHECK = 4.0;
+    private static final double PUSH_SCALE = 0.0025;
+
+    private WindParticlePusher() { }
+
+    public static Vec3 computeWindPush(Level level, Vec3 position) {
+        Player player = level.getNearestPlayer(position.x, position.y, position.z, NEAR_PLAYER_RADIUS, false);
+        if (player == null) {
+            return Vec3.ZERO;
+        }
+
+        BlockPos samplePos = BlockPos.containing(position);
+        BiomeInstanceKey key = new BiomeInstanceKey(AtmosphereUtils.getBiomeLocation(samplePos, level), samplePos);
+        WindVector wind = ForecastOrchestrator.getCurrentWind(key, level.getGameTime());
+
+        float effectiveSpeed = Math.max(wind.baseSpeed(), wind.gustSpeed());
+        if (effectiveSpeed < 0.25f) {
+            return Vec3.ZERO;
+        }
+
+        Vec3 direction = new Vec3(Math.cos(wind.angleRadians()), 0.0, Math.sin(wind.angleRadians()));
+        if (direction.lengthSqr() < 1.0E-6) {
+            return Vec3.ZERO;
+        }
+
+        if (isUpwindBlocked(level, position, direction)) {
+            return Vec3.ZERO;
+        }
+
+        return direction.normalize().scale(effectiveSpeed * PUSH_SCALE);
+    }
+
+    private static boolean isUpwindBlocked(Level level, Vec3 position, Vec3 direction) {
+        Vec3 upwind = position.subtract(direction.normalize().scale(LINE_OF_SIGHT_CHECK));
+        ClipContext context = new ClipContext(upwind, position, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, null);
+        return level.clip(context).getType() != HitResult.Type.MISS;
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/particles/WindStreakParticle.java
+++ b/src/main/java/net/Gabou/projectatmosphere/particles/WindStreakParticle.java
@@ -3,6 +3,7 @@ package net.Gabou.projectatmosphere.particles;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.*;
 import net.minecraft.core.particles.SimpleParticleType;
+import net.minecraft.world.phys.Vec3;
 
 public class WindStreakParticle extends TextureSheetParticle {
     private final SpriteSet sprites;
@@ -40,6 +41,13 @@ public class WindStreakParticle extends TextureSheetParticle {
         try {
             this.setSpriteFromAge(this.sprites);
         } catch (Throwable ignored) {
+        }
+
+        Vec3 push = WindParticlePusher.computeWindPush(this.level, new Vec3(this.x, this.y, this.z));
+        if (push.lengthSqr() > 0.0) {
+            this.xd += push.x;
+            this.yd += push.y;
+            this.zd += push.z;
         }
 
         // Fade in first quarter of life


### PR DESCRIPTION
## Summary
- add layered wind forecast models with gust smoothing, tornado force computation, and player-level helpers
- integrate ForecastOrchestrator, APIs, and SimpleClouds hooks with the new WindEngine high/low wind sampling
- document the unified wind stack in CHANGES
- push nearby ground particles along unobstructed wind directions so leaves and streaks follow live wind samples

## Testing
- `gradle --no-daemon --console=plain build` *(fails: missing Java 17 toolchain in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692d9e04f8648322a9595790e0672f52)