### PR TITLE
Add telemetry export collector and client commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ This file records functionality additions/removals made during development sessi
 - Added region orchestrator scaffolding (`modules/region`) and region-based sampling APIs in `ForecastOrchestrator`, `AtmoApi`, and `ForecastSampling`.
 - Spikes are region-only (no biome-generation spikes); BiomeChangeManager now tracks regions (and last biome for compatibility) and regenerates when entering a new region or moving ~80% of region size.
 - Cloud sampling uses region centers; far clouds culled; SimpleClouds spawn compatibility rejects spawns beyond 10k from players and biases closer spawns.
+- Added a client-only telemetry collector with bounded buffers plus `/pa debug export` to serialize session JSONL files and zip them asynchronously with clickable chat links; exports respect a retention window and configurable enable flag.
 ## Unreleased — Async active-region scheduler
 - Added `AtmosphericUpdateScheduler` to refresh only player-proximate states every 20 ticks and batch passive regions through a round-robin queue every 100 ticks using `AsyncAtmosphereService`.
 - Sunlight/rain/relaxation now apply as clamped deltas on the main thread after async computation, with stronger sunlight blending and per-variable safety clamps (temperature floored at -273.15C, pressure limited to 870–1080 hPa).

--- a/src/main/java/net/Gabou/projectatmosphere/command/TelemetryDebugClientCommand.java
+++ b/src/main/java/net/Gabou/projectatmosphere/command/TelemetryDebugClientCommand.java
@@ -1,0 +1,49 @@
+package net.Gabou.projectatmosphere.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
+import net.Gabou.projectatmosphere.telemetry.TelemetryExportService;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RegisterClientCommandsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
+public class TelemetryDebugClientCommand {
+
+    @SubscribeEvent
+    public static void onRegisterClientCommand(RegisterClientCommandsEvent event) {
+        CommandDispatcher<CommandSourceStack> dispatcher = event.getDispatcher();
+
+        dispatcher.register(
+                LiteralArgumentBuilder.<CommandSourceStack>literal("pa")
+                        .then(Commands.literal("debug")
+                                .then(Commands.literal("export")
+                                        .executes(ctx -> {
+                                            if (!AtmoCommonConfig.TELEMETRY_ENABLED.get()) {
+                                                ctx.getSource().sendFailure(Component.literal("Telemetry export is disabled in the config."));
+                                                return 0;
+                                            }
+                                            ctx.getSource().sendSuccess(() -> Component.literal("Preparing telemetry archive..."), false);
+                                            TelemetryExportService.get().exportAsync(ctx.getSource());
+                                            return 1;
+                                        })
+                                )
+                                .then(Commands.literal("open")
+                                        .executes(ctx -> {
+                                            if (!AtmoCommonConfig.TELEMETRY_ENABLED.get()) {
+                                                ctx.getSource().sendFailure(Component.literal("Telemetry export is disabled in the config."));
+                                                return 0;
+                                            }
+                                            TelemetryExportService.get().openTelemetryFolder(ctx.getSource());
+                                            return 1;
+                                        })
+                                )
+                        )
+        );
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/config/AtmoCommonConfig.java
+++ b/src/main/java/net/Gabou/projectatmosphere/config/AtmoCommonConfig.java
@@ -59,6 +59,8 @@ public class AtmoCommonConfig {
     public static final ForgeConfigSpec.DoubleValue WIND_PUSH_THRESHOLD_MPS;
     public static final ForgeConfigSpec.DoubleValue WIND_PLAYER_PUSH_SCALE;
     public static final ForgeConfigSpec.DoubleValue WIND_ENTITY_PUSH_SCALE;
+    public static final ForgeConfigSpec.BooleanValue TELEMETRY_ENABLED;
+    public static final ForgeConfigSpec.IntValue TELEMETRY_RETENTION_DAYS;
 
     static {
         ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
@@ -178,6 +180,15 @@ public class AtmoCommonConfig {
         WIND_ENTITY_PUSH_SCALE = builder
                 .comment("Push scale applied to other entities")
                 .defineInRange("entityPushScale", 0.03d, 0d, 1d);
+        builder.pop();
+
+        builder.push("telemetry");
+        TELEMETRY_ENABLED = builder
+                .comment("Enable lightweight telemetry collection for diagnostics")
+                .define("enableTelemetry", true);
+        TELEMETRY_RETENTION_DAYS = builder
+                .comment("Number of days to retain exported telemetry archives before pruning")
+                .defineInRange("telemetryRetentionDays", 14, 0, 365);
         builder.pop();
 
         builder.push("debug");

--- a/src/main/java/net/Gabou/projectatmosphere/telemetry/TelemetryCollector.java
+++ b/src/main/java/net/Gabou/projectatmosphere/telemetry/TelemetryCollector.java
@@ -1,0 +1,186 @@
+package net.Gabou.projectatmosphere.telemetry;
+
+import com.google.common.hash.Hashing;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import net.Gabou.projectatmosphere.ProjectAtmosphere;
+import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
+import net.minecraft.SharedConstants;
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.fml.loading.FMLLoader;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static net.Gabou.projectatmosphere.telemetry.TelemetryModels.*;
+
+/**
+ * In-memory telemetry collector honoring the diagnostic storage constraints.
+ *
+ *  - Bounded buffers for timelines and events.
+ *  - No disk IO until explicit export or anomaly flush.
+ *  - Stores summaries instead of tick-by-tick state.
+ */
+public final class TelemetryCollector {
+
+    private static final Gson GSON = new GsonBuilder().create();
+    private static final int DEFAULT_TIMELINE_CAP = 240; // ~10 Minecraft days if sampled hourly
+    private static final int DEFAULT_FORECAST_CAP = 90;  // 3 dominant biomes x 30 days
+    private static final int DEFAULT_CLOUD_EVENT_CAP = 256;
+    private static final int DEFAULT_DECISION_CAP = 128;
+    private static final int DEFAULT_ANOMALY_CAP = 64;
+
+    private static final TelemetryCollector INSTANCE = new TelemetryCollector();
+
+    private final TelemetryRingBuffer<PlayerExperienceSample> timeline;
+    private final TelemetryRingBuffer<DominantBiomeOccupancy> dominantBiomes;
+    private final TelemetryRingBuffer<ForecastSnapshot> forecasts;
+    private final TelemetryRingBuffer<CloudEvent> cloudEvents;
+    private final TelemetryRingBuffer<PrecipitationDecisionTrace> precipitationDecisions;
+    private final TelemetryRingBuffer<AnomalyMarker> anomalies;
+
+    private final SessionHeader header;
+
+    private TelemetryCollector() {
+        this.timeline = new TelemetryRingBuffer<>(DEFAULT_TIMELINE_CAP);
+        this.dominantBiomes = new TelemetryRingBuffer<>(30); // last 30 days
+        this.forecasts = new TelemetryRingBuffer<>(DEFAULT_FORECAST_CAP);
+        this.cloudEvents = new TelemetryRingBuffer<>(DEFAULT_CLOUD_EVENT_CAP);
+        this.precipitationDecisions = new TelemetryRingBuffer<>(DEFAULT_DECISION_CAP);
+        this.anomalies = new TelemetryRingBuffer<>(DEFAULT_ANOMALY_CAP);
+        this.header = buildHeader();
+    }
+
+    public static TelemetryCollector get() {
+        return INSTANCE;
+    }
+
+    // ----------------------- recorders -----------------------
+
+    public synchronized void recordPlayerSample(PlayerExperienceSample sample) {
+        timeline.add(sample);
+    }
+
+    public synchronized void recordDominantBiome(DominantBiomeOccupancy entry) {
+        dominantBiomes.add(entry);
+    }
+
+    public synchronized void recordForecastSnapshot(ForecastSnapshot snapshot) {
+        forecasts.add(snapshot);
+    }
+
+    public synchronized void recordCloudEvent(CloudEvent event) {
+        if (event instanceof CloudDied died) {
+            removeCloudEvents(died.cloudId());
+        }
+        cloudEvents.add(event);
+    }
+
+    private synchronized void removeCloudEvents(String cloudId) {
+        List<CloudEvent> current = new ArrayList<>(cloudEvents.snapshot());
+        current.removeIf(ev -> ev.cloudId().equals(cloudId));
+        cloudEvents.replaceAll(current);
+    }
+
+    public synchronized void recordDecision(PrecipitationDecisionTrace trace) {
+        precipitationDecisions.add(trace);
+    }
+
+    public synchronized void recordAnomaly(AnomalyMarker marker) {
+        anomalies.add(marker);
+    }
+
+    // ----------------------- export helpers -----------------------
+
+    public synchronized SessionHeader getHeader() {
+        return header;
+    }
+
+    public synchronized TelemetrySnapshot snapshot() {
+        return new TelemetrySnapshot(
+                header,
+                timeline.snapshot(),
+                dominantBiomes.snapshot(),
+                forecasts.snapshot(),
+                cloudEvents.snapshot(),
+                precipitationDecisions.snapshot(),
+                anomalies.snapshot()
+        );
+    }
+
+    public void writeSnapshot(Path outputDir) throws Exception {
+        Files.createDirectories(outputDir);
+        TelemetrySnapshot snapshot = snapshot();
+
+        writeJsonLines(outputDir.resolve("session_header.jsonl"), List.of(snapshot.header()));
+        writeJsonLines(outputDir.resolve("player_timeline.jsonl"), snapshot.timeline());
+        writeJsonLines(outputDir.resolve("dominant_biomes.jsonl"), snapshot.dominantBiomes());
+        writeJsonLines(outputDir.resolve("forecast_snapshots.jsonl"), snapshot.forecasts());
+        writeJsonLines(outputDir.resolve("cloud_events.jsonl"), snapshot.cloudEvents());
+        writeJsonLines(outputDir.resolve("precipitation_traces.jsonl"), snapshot.precipitationTraces());
+        writeJsonLines(outputDir.resolve("anomalies.jsonl"), snapshot.anomalies());
+    }
+
+    private void writeJsonLines(Path file, List<?> payload) throws Exception {
+        if (payload.isEmpty()) {
+            Files.deleteIfExists(file);
+            return;
+        }
+        Files.createDirectories(file.getParent());
+        try (var writer = Files.newBufferedWriter(file)) {
+            for (Object obj : payload) {
+                writer.write(GSON.toJson(obj));
+                writer.newLine();
+            }
+        }
+    }
+
+    private SessionHeader buildHeader() {
+        String paVersion = ModList.get().getModContainerById(ProjectAtmosphere.MODID)
+                .map(c -> c.getModInfo().getVersion().toString())
+                .orElse("unknown");
+        String mcVersion = SharedConstants.getCurrentVersion().getName();
+        String loader = "Forge " + FMLLoader.versionInfo().forgeVersion();
+        Map<String, Object> selectedValues = new HashMap<>();
+        selectedValues.put("forceSharedExecutor", AtmoCommonConfig.FORCE_SHARED_EXECUTOR.get());
+        selectedValues.put("cloudRenderDistance", AtmoCommonConfig.CLOUD_RENDER_DISTANCE.get());
+        selectedValues.put("debugMode", AtmoCommonConfig.DEBUG_MODE.get());
+
+        String configHash = Hashing.sha256()
+                .hashString(selectedValues.toString(), StandardCharsets.UTF_8)
+                .toString();
+
+        List<String> compatMods = ModList.get().getMods().stream()
+                .filter(info -> info.getModId().toLowerCase().contains("cloud") || info.getDisplayName().toLowerCase().contains("weather"))
+                .map(info -> info.getModId() + "@" + info.getVersion())
+                .toList();
+
+        return new SessionHeader(
+                UUID.randomUUID().toString(),
+                paVersion,
+                mcVersion,
+                loader,
+                configHash,
+                Collections.unmodifiableMap(selectedValues),
+                Collections.unmodifiableList(compatMods),
+                null,
+                "1.0"
+        );
+    }
+
+    public record TelemetrySnapshot(SessionHeader header,
+                                    List<PlayerExperienceSample> timeline,
+                                    List<DominantBiomeOccupancy> dominantBiomes,
+                                    List<ForecastSnapshot> forecasts,
+                                    List<CloudEvent> cloudEvents,
+                                    List<PrecipitationDecisionTrace> precipitationTraces,
+                                    List<AnomalyMarker> anomalies) {
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/telemetry/TelemetryExportService.java
+++ b/src/main/java/net/Gabou/projectatmosphere/telemetry/TelemetryExportService.java
@@ -1,0 +1,184 @@
+package net.Gabou.projectatmosphere.telemetry;
+
+import net.Gabou.projectatmosphere.ProjectAtmosphere;
+import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.SessionHeader;
+import net.Gabou.projectatmosphere.util.AsyncAtmosphereService;
+import net.minecraft.Util;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * Service responsible for writing telemetry snapshots to disk and packaging them into a zip archive.
+ * Work is dispatched onto the CLIENT executor to avoid blocking the render thread.
+ */
+public final class TelemetryExportService {
+
+    private static final TelemetryExportService INSTANCE = new TelemetryExportService();
+
+    private TelemetryExportService() {
+    }
+
+    public static TelemetryExportService get() {
+        return INSTANCE;
+    }
+
+    public CompletableFuture<Path> exportAsync(CommandSourceStack source) {
+        CompletableFuture<Path> future = new CompletableFuture<>();
+        AsyncAtmosphereService.runClient(() -> {
+            try {
+                Path archive = exportNow();
+                AsyncAtmosphereService.runOnMainThread(() -> notifySuccess(source, archive));
+                future.complete(archive);
+            } catch (Exception e) {
+                ProjectAtmosphere.LOGGER.error("Telemetry export failed", e);
+                AsyncAtmosphereService.runOnMainThread(() -> notifyFailure(source, e));
+                future.completeExceptionally(e);
+            }
+        });
+        return future;
+    }
+
+    public void openTelemetryFolder(CommandSourceStack source) {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc == null) {
+            notifyFailure(source, new IllegalStateException("Minecraft client not available"));
+            return;
+        }
+        Path telemetryDir = getTelemetryDirectory(mc);
+        try {
+            Files.createDirectories(telemetryDir);
+            Util.getPlatform().openUri(telemetryDir.toUri());
+        } catch (Exception e) {
+            notifyFailure(source, e);
+        }
+    }
+
+    private Path exportNow() throws Exception {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc == null) {
+            throw new IllegalStateException("Client export only");
+        }
+        if (!AtmoCommonConfig.TELEMETRY_ENABLED.get()) {
+            throw new IllegalStateException("Telemetry export disabled in config");
+        }
+
+        Path telemetryDir = getTelemetryDirectory(mc);
+        Files.createDirectories(telemetryDir);
+
+        TelemetryCollector collector = TelemetryCollector.get();
+        String sessionId = collector.getHeader().sessionId;
+        Path sessionDir = telemetryDir.resolve("session_" + sessionId);
+        collector.writeSnapshot(sessionDir);
+
+        Path archivePath = buildArchivePath(telemetryDir, collector.getHeader());
+        zipDirectory(sessionDir, archivePath);
+        pruneOldArchives(telemetryDir);
+        return archivePath;
+    }
+
+    private Path getTelemetryDirectory(Minecraft mc) {
+        return mc.gameDirectory.toPath()
+                .resolve("project_atmosphere")
+                .resolve("telemetry");
+    }
+
+    private Path buildArchivePath(Path telemetryDir, SessionHeader header) throws IOException {
+        String paVersion = header.projectAtmosphereVersion;
+        String mcVersion = header.minecraftVersion;
+        String timestamp = new SimpleDateFormat("yyyy_MM_dd_HH_mm", Locale.ROOT).format(new Date());
+        String sessionShort = header.sessionId.substring(0, Math.min(6, header.sessionId.length()));
+        String baseName = String.format(Locale.ROOT, "pa_telemetry_%s_mc%s_%s_%s.zip", paVersion, mcVersion, timestamp, sessionShort);
+        Path candidate = telemetryDir.resolve(baseName);
+        int attempt = 1;
+        while (Files.exists(candidate)) {
+            candidate = telemetryDir.resolve(baseName.replace(".zip", "_" + (++attempt) + ".zip"));
+        }
+        return candidate;
+    }
+
+    private void zipDirectory(Path inputDir, Path archivePath) throws IOException {
+        try (ZipOutputStream zos = new ZipOutputStream(new BufferedOutputStream(Files.newOutputStream(archivePath, StandardOpenOption.CREATE_NEW)));
+             var paths = Files.walk(inputDir)) {
+            paths.filter(Files::isRegularFile)
+                    .forEach(path -> {
+                        Path relative = inputDir.relativize(path);
+                        try (BufferedInputStream bis = new BufferedInputStream(Files.newInputStream(path))) {
+                            ZipEntry entry = new ZipEntry(relative.toString().replace('\\', '/'));
+                            zos.putNextEntry(entry);
+                            bis.transferTo(zos);
+                            zos.closeEntry();
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+        }
+    }
+
+    private void pruneOldArchives(Path telemetryDir) {
+        int retentionDays = AtmoCommonConfig.TELEMETRY_RETENTION_DAYS.get();
+        if (retentionDays <= 0) {
+            return;
+        }
+        Instant cutoff = Instant.now().minusSeconds(retentionDays * 86_400L);
+        try (var paths = Files.list(telemetryDir)) {
+            paths.filter(path -> path.getFileName().toString().startsWith("pa_telemetry") && path.toString().endsWith(".zip"))
+                    .sorted(Comparator.naturalOrder())
+                    .forEach(path -> {
+                        try {
+                            Instant lastModified = Files.getLastModifiedTime(path).toInstant();
+                            if (lastModified.isBefore(cutoff)) {
+                                Files.deleteIfExists(path);
+                            }
+                        } catch (IOException ignored) {
+                            ProjectAtmosphere.LOGGER.debug("Failed to check telemetry archive {}", path, ignored);
+                        }
+                    });
+        } catch (IOException e) {
+            ProjectAtmosphere.LOGGER.debug("Telemetry retention scan failed", e);
+        }
+    }
+
+    private void notifySuccess(CommandSourceStack source, Path archive) {
+        MutableComponent message = Component.literal("Telemetry archive ready: " + archive)
+                .withStyle(Style.EMPTY
+                        .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, archive.toString())));
+        sendToSource(source, message);
+    }
+
+    private void notifyFailure(CommandSourceStack source, Exception e) {
+        MutableComponent message = Component.literal("Telemetry export failed: " + e.getMessage());
+        sendToSource(source, message);
+    }
+
+    private void sendToSource(CommandSourceStack source, MutableComponent message) {
+        if (source != null) {
+            source.sendSuccess(() -> message, false);
+            return;
+        }
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player != null) {
+            player.displayClientMessage(message, false);
+        }
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/telemetry/TelemetryModels.java
+++ b/src/main/java/net/Gabou/projectatmosphere/telemetry/TelemetryModels.java
@@ -1,0 +1,375 @@
+package net.Gabou.projectatmosphere.telemetry;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Immutable POJOs describing telemetry records. These are intentionally small and
+ * serialization-friendly so they can be written as JSON Lines during export.
+ */
+public final class TelemetryModels {
+
+    private TelemetryModels() {
+    }
+
+    public static final class SessionHeader {
+        public final String sessionId;
+        public final String projectAtmosphereVersion;
+        public final String minecraftVersion;
+        public final String loader;
+        public final String configHash;
+        public final Map<String, Object> selectedConfigValues;
+        public final List<String> detectedCompatMods;
+        public final String worldIdHash;
+        public final String telemetryVersion;
+
+        public SessionHeader(String projectAtmosphereVersion,
+                             String minecraftVersion,
+                             String loader,
+                             String configHash,
+                             Map<String, Object> selectedConfigValues,
+                             List<String> detectedCompatMods,
+                             String worldIdHash,
+                             String telemetryVersion) {
+            this(UUID.randomUUID().toString(), projectAtmosphereVersion, minecraftVersion, loader,
+                    configHash, selectedConfigValues, detectedCompatMods, worldIdHash, telemetryVersion);
+        }
+
+        public SessionHeader(String sessionId,
+                             String projectAtmosphereVersion,
+                             String minecraftVersion,
+                             String loader,
+                             String configHash,
+                             Map<String, Object> selectedConfigValues,
+                             List<String> detectedCompatMods,
+                             String worldIdHash,
+                             String telemetryVersion) {
+            this.sessionId = sessionId;
+            this.projectAtmosphereVersion = projectAtmosphereVersion;
+            this.minecraftVersion = minecraftVersion;
+            this.loader = loader;
+            this.configHash = configHash;
+            this.selectedConfigValues = selectedConfigValues;
+            this.detectedCompatMods = detectedCompatMods;
+            this.worldIdHash = worldIdHash;
+            this.telemetryVersion = telemetryVersion;
+        }
+    }
+
+    public static final class PlayerExperienceSample {
+        public final long gameDay;
+        public final long timeOfDay;
+        public final long realTimeSecondsSinceStart;
+        public final String dimensionId;
+        public final int positionChunkX;
+        public final int positionChunkZ;
+        public final String biomeId;
+        public final float temperature;
+        public final float humidity;
+        public final float pressure;
+        public final float windStrength;
+        public final float windDirection;
+        public final boolean vanillaIsRaining;
+        public final boolean vanillaIsThundering;
+        public final String paPrecipitationState;
+        public final boolean temperatureOutOfExpectedRange;
+        public final boolean precipitationStuck;
+        public final boolean suddenJumpDetected;
+
+        public PlayerExperienceSample(long gameDay, long timeOfDay, long realTimeSecondsSinceStart,
+                                      String dimensionId, int positionChunkX, int positionChunkZ, String biomeId,
+                                      float temperature, float humidity, float pressure,
+                                      float windStrength, float windDirection,
+                                      boolean vanillaIsRaining, boolean vanillaIsThundering, String paPrecipitationState,
+                                      boolean temperatureOutOfExpectedRange,
+                                      boolean precipitationStuck,
+                                      boolean suddenJumpDetected) {
+            this.gameDay = gameDay;
+            this.timeOfDay = timeOfDay;
+            this.realTimeSecondsSinceStart = realTimeSecondsSinceStart;
+            this.dimensionId = dimensionId;
+            this.positionChunkX = positionChunkX;
+            this.positionChunkZ = positionChunkZ;
+            this.biomeId = biomeId;
+            this.temperature = temperature;
+            this.humidity = humidity;
+            this.pressure = pressure;
+            this.windStrength = windStrength;
+            this.windDirection = windDirection;
+            this.vanillaIsRaining = vanillaIsRaining;
+            this.vanillaIsThundering = vanillaIsThundering;
+            this.paPrecipitationState = paPrecipitationState;
+            this.temperatureOutOfExpectedRange = temperatureOutOfExpectedRange;
+            this.precipitationStuck = precipitationStuck;
+            this.suddenJumpDetected = suddenJumpDetected;
+        }
+    }
+
+    public static final class DominantBiomeOccupancy {
+        public final long gameDay;
+        public final List<OccupiedChunk> topOccupiedChunks;
+
+        public DominantBiomeOccupancy(long gameDay, List<OccupiedChunk> topOccupiedChunks) {
+            this.gameDay = gameDay;
+            this.topOccupiedChunks = topOccupiedChunks;
+        }
+    }
+
+    public static final class OccupiedChunk {
+        public final int chunkX;
+        public final int chunkZ;
+        public final long timeSpentSeconds;
+
+        public OccupiedChunk(int chunkX, int chunkZ, long timeSpentSeconds) {
+            this.chunkX = chunkX;
+            this.chunkZ = chunkZ;
+            this.timeSpentSeconds = timeSpentSeconds;
+        }
+    }
+
+    public static final class ForecastSnapshot {
+        public final String biomeId;
+        public final int sampleChunkX;
+        public final int sampleChunkZ;
+        public final int dayIndex;
+        public final ChannelSummary temperature;
+        public final ChannelSummary humidity;
+        public final ChannelSummary pressure;
+        public final ChannelSummary stormProbability;
+        public final DayCurve curve;
+        public final Modifiers modifiers;
+
+        public ForecastSnapshot(String biomeId, int sampleChunkX, int sampleChunkZ, int dayIndex,
+                                ChannelSummary temperature, ChannelSummary humidity,
+                                ChannelSummary pressure, ChannelSummary stormProbability,
+                                DayCurve curve, Modifiers modifiers) {
+            this.biomeId = biomeId;
+            this.sampleChunkX = sampleChunkX;
+            this.sampleChunkZ = sampleChunkZ;
+            this.dayIndex = dayIndex;
+            this.temperature = temperature;
+            this.humidity = humidity;
+            this.pressure = pressure;
+            this.stormProbability = stormProbability;
+            this.curve = curve;
+            this.modifiers = modifiers;
+        }
+    }
+
+    public static final class ChannelSummary {
+        public final float min;
+        public final float max;
+
+        public ChannelSummary(float min, float max) {
+            this.min = min;
+            this.max = max;
+        }
+    }
+
+    public static final class DayCurve {
+        public final Float valueAt3am;
+        public final Float valueAt9am;
+        public final Float valueAt3pm;
+        public final Float valueAt9pm;
+
+        public DayCurve(Float valueAt3am, Float valueAt9am, Float valueAt3pm, Float valueAt9pm) {
+            this.valueAt3am = valueAt3am;
+            this.valueAt9am = valueAt9am;
+            this.valueAt3pm = valueAt3pm;
+            this.valueAt9pm = valueAt9pm;
+        }
+    }
+
+    public static final class Modifiers {
+        public final boolean spikeActive;
+        public final Float spikeMagnitude;
+        public final Integer spikeRemainingDays;
+        public final boolean localJoltApplied;
+        public final String biomeTemplateId;
+
+        public Modifiers(boolean spikeActive, Float spikeMagnitude, Integer spikeRemainingDays,
+                         boolean localJoltApplied, String biomeTemplateId) {
+            this.spikeActive = spikeActive;
+            this.spikeMagnitude = spikeMagnitude;
+            this.spikeRemainingDays = spikeRemainingDays;
+            this.localJoltApplied = localJoltApplied;
+            this.biomeTemplateId = biomeTemplateId;
+        }
+    }
+
+    public sealed interface CloudEvent permits CloudCreated, CloudTickSummary, CloudEvolved, CloudMerged, CloudDied {
+        String cloudId();
+    }
+
+    public static final class CloudCreated implements CloudEvent {
+        public final String cloudId;
+        public final String cloudType;
+        public final String spawnReason;
+        public final String dimensionId;
+        public final int spawnChunkX;
+        public final int spawnChunkZ;
+        public final float baseAltitude;
+        public final float initialIntensity;
+        public final boolean precipitable;
+        public final String associatedBiomeId;
+
+        public CloudCreated(String cloudId, String cloudType, String spawnReason, String dimensionId,
+                            int spawnChunkX, int spawnChunkZ, float baseAltitude, float initialIntensity,
+                            boolean precipitable, String associatedBiomeId) {
+            this.cloudId = cloudId;
+            this.cloudType = cloudType;
+            this.spawnReason = spawnReason;
+            this.dimensionId = dimensionId;
+            this.spawnChunkX = spawnChunkX;
+            this.spawnChunkZ = spawnChunkZ;
+            this.baseAltitude = baseAltitude;
+            this.initialIntensity = initialIntensity;
+            this.precipitable = precipitable;
+            this.associatedBiomeId = associatedBiomeId;
+        }
+
+        @Override
+        public String cloudId() {
+            return cloudId;
+        }
+    }
+
+    public static final class CloudTickSummary implements CloudEvent {
+        public final String cloudId;
+        public final int chunkX;
+        public final int chunkZ;
+        public final float velocityMagnitude;
+        public final boolean precipitationActive;
+        public final float intensity;
+        public final float lifetimeRemaining;
+
+        public CloudTickSummary(String cloudId, int chunkX, int chunkZ, float velocityMagnitude,
+                                boolean precipitationActive, float intensity, float lifetimeRemaining) {
+            this.cloudId = cloudId;
+            this.chunkX = chunkX;
+            this.chunkZ = chunkZ;
+            this.velocityMagnitude = velocityMagnitude;
+            this.precipitationActive = precipitationActive;
+            this.intensity = intensity;
+            this.lifetimeRemaining = lifetimeRemaining;
+        }
+
+        @Override
+        public String cloudId() {
+            return cloudId;
+        }
+    }
+
+    public static final class CloudEvolved implements CloudEvent {
+        public final String cloudId;
+        public final String fromType;
+        public final String toType;
+        public final String evolutionReason;
+        public final Map<String, Object> parametersBefore;
+        public final Map<String, Object> parametersAfter;
+
+        public CloudEvolved(String cloudId, String fromType, String toType, String evolutionReason,
+                            Map<String, Object> parametersBefore, Map<String, Object> parametersAfter) {
+            this.cloudId = cloudId;
+            this.fromType = fromType;
+            this.toType = toType;
+            this.evolutionReason = evolutionReason;
+            this.parametersBefore = parametersBefore;
+            this.parametersAfter = parametersAfter;
+        }
+
+        @Override
+        public String cloudId() {
+            return cloudId;
+        }
+    }
+
+    public static final class CloudMerged implements CloudEvent {
+        public final String newCloudId;
+        public final List<String> sourceCloudIds;
+        public final String resultingType;
+
+        public CloudMerged(String newCloudId, List<String> sourceCloudIds, String resultingType) {
+            this.newCloudId = newCloudId;
+            this.sourceCloudIds = sourceCloudIds;
+            this.resultingType = resultingType;
+        }
+
+        @Override
+        public String cloudId() {
+            return newCloudId;
+        }
+    }
+
+    public static final class CloudDied implements CloudEvent {
+        public final String cloudId;
+        public final int endChunkX;
+        public final int endChunkZ;
+        public final float lifetime;
+        public final String deathReason;
+
+        public CloudDied(String cloudId, int endChunkX, int endChunkZ, float lifetime, String deathReason) {
+            this.cloudId = cloudId;
+            this.endChunkX = endChunkX;
+            this.endChunkZ = endChunkZ;
+            this.lifetime = lifetime;
+            this.deathReason = deathReason;
+        }
+
+        @Override
+        public String cloudId() {
+            return cloudId;
+        }
+    }
+
+    public static final class PrecipitationDecisionTrace {
+        public final Instant timestamp;
+        public final String biomeId;
+        public final int sampleChunkX;
+        public final int sampleChunkZ;
+        public final float temperature;
+        public final float humidity;
+        public final float pressure;
+        public final float dewPoint;
+        public final float stormProbability;
+        public final boolean precipitationAllowed;
+        public final float intensity;
+        public final List<String> gatesPassed;
+        public final List<String> gatesFailed;
+
+        public PrecipitationDecisionTrace(Instant timestamp, String biomeId, int sampleChunkX, int sampleChunkZ,
+                                          float temperature, float humidity, float pressure, float dewPoint,
+                                          float stormProbability, boolean precipitationAllowed, float intensity,
+                                          List<String> gatesPassed, List<String> gatesFailed) {
+            this.timestamp = timestamp;
+            this.biomeId = biomeId;
+            this.sampleChunkX = sampleChunkX;
+            this.sampleChunkZ = sampleChunkZ;
+            this.temperature = temperature;
+            this.humidity = humidity;
+            this.pressure = pressure;
+            this.dewPoint = dewPoint;
+            this.stormProbability = stormProbability;
+            this.precipitationAllowed = precipitationAllowed;
+            this.intensity = intensity;
+            this.gatesPassed = gatesPassed;
+            this.gatesFailed = gatesFailed;
+        }
+    }
+
+    public static final class AnomalyMarker {
+        public final Instant timestamp;
+        public final String anomalyType;
+        public final String relatedSampleId;
+        public final Map<String, Object> contextData;
+
+        public AnomalyMarker(Instant timestamp, String anomalyType, String relatedSampleId, Map<String, Object> contextData) {
+            this.timestamp = timestamp;
+            this.anomalyType = anomalyType;
+            this.relatedSampleId = relatedSampleId;
+            this.contextData = contextData;
+        }
+    }
+}

--- a/src/main/java/net/Gabou/projectatmosphere/telemetry/TelemetryRingBuffer.java
+++ b/src/main/java/net/Gabou/projectatmosphere/telemetry/TelemetryRingBuffer.java
@@ -1,0 +1,48 @@
+package net.Gabou.projectatmosphere.telemetry;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Lightweight bounded queue used by the telemetry collector. The buffer drops the oldest
+ * entries to avoid unbounded memory growth and supports snapshotting for export.
+ */
+public final class TelemetryRingBuffer<T> {
+
+    private final int capacity;
+    private final ArrayDeque<T> queue;
+
+    public TelemetryRingBuffer(int capacity) {
+        this.capacity = Math.max(1, capacity);
+        this.queue = new ArrayDeque<>(this.capacity);
+    }
+
+    public synchronized void add(T value) {
+        if (queue.size() >= capacity) {
+            queue.pollFirst();
+        }
+        queue.addLast(value);
+    }
+
+    public synchronized void addAll(Collection<T> values) {
+        for (T value : values) {
+            add(value);
+        }
+    }
+
+    public synchronized List<T> snapshot() {
+        return Collections.unmodifiableList(new ArrayList<>(queue));
+    }
+
+    public synchronized void replaceAll(Collection<T> values) {
+        queue.clear();
+        addAll(values);
+    }
+
+    public int capacity() {
+        return capacity;
+    }
+}


### PR DESCRIPTION
## Summary
- add bounded telemetry models and collector to hold session diagnostics until export
- implement client-side telemetry export service that zips JSONL snapshots with retention pruning and clickable chat feedback
- expose /pa debug export/open commands plus telemetry configuration toggles and changelog entry

## Testing
- gradle build --console plain *(fails: missing Java 17 toolchain in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694075c991d8832290f76aa4ece33099)