### PR TITLE
Add telemetry hooks for client sampling and weather decisions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -126,7 +126,7 @@ This file records functionality additions/removals made during development sessi
 - Added tornado-aware low wind forces plus helpers to apply combined wind, gust, and suction/rotation/lift to players.
 - Wired SimpleClouds and forecast orchestration to consume the new wind API while preserving existing forecast generation inputs.
 - Ground-level wind particles near players now receive directional pushes when the airflow is unobstructed, keeping leaves and streaks aligned with live wind samples.
-- Client telemetry now records player weather samples, dominant chunk occupancy, forecast snapshots, cloud lifecycle events, precipitation gate decisions, and temperature anomalies for `/pa debug export`.
+- Server-side telemetry now records player weather samples, dominant chunk occupancy, forecast snapshots, cloud lifecycle events, precipitation gate decisions, and temperature anomalies for `/pa debug export`.
 
 ## 0.5.4.4 — Added weatherdebug cloud command (2025-10-17)
 - Added command: `/weatherdebug cloud <id>`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -126,6 +126,7 @@ This file records functionality additions/removals made during development sessi
 - Added tornado-aware low wind forces plus helpers to apply combined wind, gust, and suction/rotation/lift to players.
 - Wired SimpleClouds and forecast orchestration to consume the new wind API while preserving existing forecast generation inputs.
 - Ground-level wind particles near players now receive directional pushes when the airflow is unobstructed, keeping leaves and streaks aligned with live wind samples.
+- Client telemetry now records player weather samples, dominant chunk occupancy, forecast snapshots, cloud lifecycle events, precipitation gate decisions, and temperature anomalies for `/pa debug export`.
 
 ## 0.5.4.4 — Added weatherdebug cloud command (2025-10-17)
 - Added command: `/weatherdebug cloud <id>`

--- a/src/main/java/net/Gabou/projectatmosphere/client/ClientTickHandler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/client/ClientTickHandler.java
@@ -9,10 +9,6 @@ import net.Gabou.projectatmosphere.modules.tornado.TornadoManager;
 import net.Gabou.projectatmosphere.client.sound.TornadoAudioClient;
 import net.Gabou.projectatmosphere.modules.wind.WindMath;
 import net.Gabou.projectatmosphere.registry.ModParticles;
-import net.Gabou.projectatmosphere.telemetry.TelemetryCollector;
-import net.Gabou.projectatmosphere.telemetry.TelemetryModels.DominantBiomeOccupancy;
-import net.Gabou.projectatmosphere.telemetry.TelemetryModels.OccupiedChunk;
-import net.Gabou.projectatmosphere.telemetry.TelemetryModels.PlayerExperienceSample;
 import net.Gabou.projectatmosphere.util.AsyncAtmosphereService;
 import net.Gabou.projectatmosphere.util.AtmosphereUtils;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
@@ -29,12 +25,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.Gabou.projectatmosphere.seasons.SeasonStage;
 import net.Gabou.projectatmosphere.seasons.SeasonTimeHelper;
 
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -49,10 +40,6 @@ public class ClientTickHandler {
     private static int tickCounter = 0;
     private static final Set<TornadoInstance> prevTornadoes = new HashSet<>();
     private static final Set<Integer> culledRegionIds = new HashSet<>();
-    private static final Map<Long, Long> chunkOccupancyTicks = new LinkedHashMap<>();
-
-    private static final long CLIENT_SESSION_START_MS = System.currentTimeMillis();
-
     private static final double CLOUD_RENDER_DISTANCE = AtmoCommonConfig.CLOUD_RENDER_DISTANCE.get();
 
     private static int getRegionId(CloudRegion region) {
@@ -155,79 +142,6 @@ public class ClientTickHandler {
             }
         }
 
-        if (mc.level != null && mc.player != null && AtmoCommonConfig.TELEMETRY_ENABLED.get()) {
-            recordTelemetry(mc);
-        }
-    }
-
-    private static void recordTelemetry(Minecraft mc) {
-        BlockPos pos = mc.player.blockPosition();
-        long gameTime = mc.level.getGameTime();
-        long key = chunkKey(pos.getX() >> 4, pos.getZ() >> 4);
-        chunkOccupancyTicks.merge(key, 1L, Long::sum);
-
-        if (tickCounter % 200 == 0) {
-            recordPlayerSample(mc, pos, gameTime);
-        }
-        if (tickCounter % 1200 == 0) {
-            emitDominantBiomeOccupancy(gameTime);
-        }
-    }
-
-    private static void recordPlayerSample(Minecraft mc, BlockPos pos, long gameTime) {
-        TelemetryCollector collector = TelemetryCollector.get();
-        BiomeInstanceKey key = new BiomeInstanceKey(AtmosphereUtils.getBiomeLocation(pos, mc.level), pos);
-        float temperature = ForecastOrchestrator.getCurrentTemperature(key, gameTime);
-        float humidity = ForecastOrchestrator.getCurrentHumidity(key, gameTime);
-        float pressure = ForecastOrchestrator.getCurrentPressure(key, gameTime);
-        WindVector wind = ForecastOrchestrator.getCurrentWind(key, gameTime);
-        float windStrength = wind.baseSpeed();
-        float windDirection = wind.angleRadians();
-        boolean isRaining = CloudManager.get(mc.level).isRainingAt(pos);
-        boolean temperatureOutOfRange = temperature < -60f || temperature > 60f;
-
-        PlayerExperienceSample sample = new PlayerExperienceSample(
-                gameTime / 24000L,
-                gameTime % 24000L,
-                (System.currentTimeMillis() - CLIENT_SESSION_START_MS) / 1000L,
-                mc.level.dimension().location().toString(),
-                pos.getX() >> 4,
-                pos.getZ() >> 4,
-                key.biomeType().toString(),
-                temperature,
-                humidity,
-                pressure,
-                windStrength,
-                windDirection,
-                mc.level.isRaining(),
-                mc.level.isThundering(),
-                isRaining ? "RAINING" : "CLEAR",
-                temperatureOutOfRange,
-                false,
-                false
-        );
-        collector.recordPlayerSample(sample);
-    }
-
-    private static void emitDominantBiomeOccupancy(long gameTime) {
-        if (chunkOccupancyTicks.isEmpty()) {
-            return;
-        }
-        List<OccupiedChunk> top = new ArrayList<>();
-        chunkOccupancyTicks.entrySet().stream()
-                .sorted(Map.Entry.<Long, Long>comparingByValue(Comparator.naturalOrder()).reversed())
-                .limit(5)
-                .forEach(entry -> {
-                    int cx = (int) (entry.getKey() >> 32);
-                    int cz = (int) (entry.getKey().longValue());
-                    long seconds = entry.getValue() / 20L;
-                    top.add(new OccupiedChunk(cx, cz, seconds));
-                });
-        TelemetryCollector.get().recordDominantBiome(new DominantBiomeOccupancy(gameTime / 24000L, top));
-    }
-
-    private static long chunkKey(int chunkX, int chunkZ) {
-        return ((long) chunkX << 32) | (chunkZ & 0xFFFFFFFFL);
     }
 
     public static SimpleParticleType getSeasonalLeafParticle(ClientLevel level, BlockPos pos, RandomSource random) {

--- a/src/main/java/net/Gabou/projectatmosphere/client/ClientTickHandler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/client/ClientTickHandler.java
@@ -9,6 +9,10 @@ import net.Gabou.projectatmosphere.modules.tornado.TornadoManager;
 import net.Gabou.projectatmosphere.client.sound.TornadoAudioClient;
 import net.Gabou.projectatmosphere.modules.wind.WindMath;
 import net.Gabou.projectatmosphere.registry.ModParticles;
+import net.Gabou.projectatmosphere.telemetry.TelemetryCollector;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.DominantBiomeOccupancy;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.OccupiedChunk;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.PlayerExperienceSample;
 import net.Gabou.projectatmosphere.util.AsyncAtmosphereService;
 import net.Gabou.projectatmosphere.util.AtmosphereUtils;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
@@ -25,8 +29,12 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.Gabou.projectatmosphere.seasons.SeasonStage;
 import net.Gabou.projectatmosphere.seasons.SeasonTimeHelper;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -41,6 +49,9 @@ public class ClientTickHandler {
     private static int tickCounter = 0;
     private static final Set<TornadoInstance> prevTornadoes = new HashSet<>();
     private static final Set<Integer> culledRegionIds = new HashSet<>();
+    private static final Map<Long, Long> chunkOccupancyTicks = new LinkedHashMap<>();
+
+    private static final long CLIENT_SESSION_START_MS = System.currentTimeMillis();
 
     private static final double CLOUD_RENDER_DISTANCE = AtmoCommonConfig.CLOUD_RENDER_DISTANCE.get();
 
@@ -143,6 +154,80 @@ public class ClientTickHandler {
                 }
             }
         }
+
+        if (mc.level != null && mc.player != null && AtmoCommonConfig.TELEMETRY_ENABLED.get()) {
+            recordTelemetry(mc);
+        }
+    }
+
+    private static void recordTelemetry(Minecraft mc) {
+        BlockPos pos = mc.player.blockPosition();
+        long gameTime = mc.level.getGameTime();
+        long key = chunkKey(pos.getX() >> 4, pos.getZ() >> 4);
+        chunkOccupancyTicks.merge(key, 1L, Long::sum);
+
+        if (tickCounter % 200 == 0) {
+            recordPlayerSample(mc, pos, gameTime);
+        }
+        if (tickCounter % 1200 == 0) {
+            emitDominantBiomeOccupancy(gameTime);
+        }
+    }
+
+    private static void recordPlayerSample(Minecraft mc, BlockPos pos, long gameTime) {
+        TelemetryCollector collector = TelemetryCollector.get();
+        BiomeInstanceKey key = new BiomeInstanceKey(AtmosphereUtils.getBiomeLocation(pos, mc.level), pos);
+        float temperature = ForecastOrchestrator.getCurrentTemperature(key, gameTime);
+        float humidity = ForecastOrchestrator.getCurrentHumidity(key, gameTime);
+        float pressure = ForecastOrchestrator.getCurrentPressure(key, gameTime);
+        WindVector wind = ForecastOrchestrator.getCurrentWind(key, gameTime);
+        float windStrength = wind.baseSpeed();
+        float windDirection = wind.angleRadians();
+        boolean isRaining = CloudManager.get(mc.level).isRainingAt(pos);
+        boolean temperatureOutOfRange = temperature < -60f || temperature > 60f;
+
+        PlayerExperienceSample sample = new PlayerExperienceSample(
+                gameTime / 24000L,
+                gameTime % 24000L,
+                (System.currentTimeMillis() - CLIENT_SESSION_START_MS) / 1000L,
+                mc.level.dimension().location().toString(),
+                pos.getX() >> 4,
+                pos.getZ() >> 4,
+                key.biomeType().toString(),
+                temperature,
+                humidity,
+                pressure,
+                windStrength,
+                windDirection,
+                mc.level.isRaining(),
+                mc.level.isThundering(),
+                isRaining ? "RAINING" : "CLEAR",
+                temperatureOutOfRange,
+                false,
+                false
+        );
+        collector.recordPlayerSample(sample);
+    }
+
+    private static void emitDominantBiomeOccupancy(long gameTime) {
+        if (chunkOccupancyTicks.isEmpty()) {
+            return;
+        }
+        List<OccupiedChunk> top = new ArrayList<>();
+        chunkOccupancyTicks.entrySet().stream()
+                .sorted(Map.Entry.<Long, Long>comparingByValue(Comparator.naturalOrder()).reversed())
+                .limit(5)
+                .forEach(entry -> {
+                    int cx = (int) (entry.getKey() >> 32);
+                    int cz = (int) (entry.getKey().longValue());
+                    long seconds = entry.getValue() / 20L;
+                    top.add(new OccupiedChunk(cx, cz, seconds));
+                });
+        TelemetryCollector.get().recordDominantBiome(new DominantBiomeOccupancy(gameTime / 24000L, top));
+    }
+
+    private static long chunkKey(int chunkX, int chunkZ) {
+        return ((long) chunkX << 32) | (chunkZ & 0xFFFFFFFFL);
     }
 
     public static SimpleParticleType getSeasonalLeafParticle(ClientLevel level, BlockPos pos, RandomSource random) {

--- a/src/main/java/net/Gabou/projectatmosphere/modules/atmosphere/AtmosphericUpdateScheduler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/atmosphere/AtmosphericUpdateScheduler.java
@@ -1,6 +1,9 @@
 package net.Gabou.projectatmosphere.modules.atmosphere;
 
 import net.Gabou.projectatmosphere.async.PoolType;
+import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
+import net.Gabou.projectatmosphere.telemetry.TelemetryCollector;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.AnomalyMarker;
 import net.Gabou.projectatmosphere.util.AsyncAtmosphereService;
 import net.Gabou.projectatmosphere.util.RegionInstanceKey;
 import net.minecraft.core.BlockPos;
@@ -8,6 +11,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 
+import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -15,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -36,6 +41,7 @@ public final class AtmosphericUpdateScheduler {
     private static final AtomicBoolean ACTIVE_IN_FLIGHT = new AtomicBoolean();
     private static final AtomicBoolean PASSIVE_IN_FLIGHT = new AtomicBoolean();
     private static final ArrayDeque<RegionInstanceKey> PASSIVE_QUEUE = new ArrayDeque<>();
+    private static final Set<RegionInstanceKey> REPORTED_ANOMALIES = ConcurrentHashMap.newKeySet();
 
     private static long lastActiveTick = -ACTIVE_INTERVAL_TICKS;
     private static long lastPassiveTick = 0L;
@@ -268,6 +274,22 @@ public final class AtmosphericUpdateScheduler {
             if (mode == UpdateMode.ACTIVE) {
                 state.recordDailySnapshot(dayTime);
             }
+            if (AtmoCommonConfig.TELEMETRY_ENABLED.get()) {
+                recordAnomalies(state);
+            }
+        }
+    }
+
+    private static void recordAnomalies(RegionAtmosphereState state) {
+        float temperature = state.getTemperature();
+        boolean outlier = temperature < -80f || temperature > 80f;
+        if (outlier && REPORTED_ANOMALIES.add(state.getRegionId())) {
+            TelemetryCollector.get().recordAnomaly(new AnomalyMarker(
+                    Instant.now(),
+                    "temperature_outlier",
+                    state.getRegionId().toString(),
+                    Map.of("temperature", temperature)
+            ));
         }
     }
 

--- a/src/main/java/net/Gabou/projectatmosphere/modules/atmosphere/CloudManager.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/atmosphere/CloudManager.java
@@ -8,9 +8,15 @@ import dev.nonamecrackers2.simpleclouds.common.world.SpawnRegion;
 import net.Gabou.projectatmosphere.ProjectAtmosphere;
 import net.Gabou.projectatmosphere.async.PoolType;
 import net.Gabou.projectatmosphere.compat.SimpleCloudsCompat;
+import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
 import net.Gabou.projectatmosphere.manager.SimpleCloudSpawner;
 import net.Gabou.projectatmosphere.modules.core.CloudLibrary;
 import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.Gabou.projectatmosphere.telemetry.TelemetryCollector;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.CloudCreated;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.CloudDied;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.CloudTickSummary;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.PrecipitationDecisionTrace;
 import net.Gabou.projectatmosphere.util.AsyncAtmosphereService;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
 import net.Gabou.projectatmosphere.util.RegionInstanceKey;
@@ -25,6 +31,7 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.util.valueproviders.BiasedToBottomInt;
 import org.joml.Vector2i;
 
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -39,6 +46,9 @@ import static net.Gabou.projectatmosphere.manager.SimpleCloudSpawner.determineCl
  */
 public final class CloudManager {
     private static final Map<Integer, RegionCloudData> REGION_DATA = new ConcurrentHashMap<>();
+    private static final Map<Integer, Long> CLOUD_BIRTH_TICK = new ConcurrentHashMap<>();
+    private static final Map<Integer, Vector2i> CLOUD_LAST_POS = new ConcurrentHashMap<>();
+    private static final Map<Integer, ResourceLocation> CLOUD_TYPES = new ConcurrentHashMap<>();
     private static final Set<RegionInstanceKey> ACTIVE_REGIONS = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     private static final AtomicBoolean REGION_SCAN_IN_FLIGHT = new AtomicBoolean();
@@ -80,6 +90,9 @@ public final class CloudManager {
     public static void initialize(ServerLevel level) {
         REGION_DATA.clear();
         ACTIVE_REGIONS.clear();
+        CLOUD_BIRTH_TICK.clear();
+        CLOUD_LAST_POS.clear();
+        CLOUD_TYPES.clear();
         lastRegionSampleTick = 0L;
         lastSpawnTick = 0L;
         REGION_SCAN_IN_FLIGHT.set(false);
@@ -285,6 +298,15 @@ public final class CloudManager {
             observed.add(sample.id());
 
             RegionCloudData data = REGION_DATA.computeIfAbsent(sample.id(), ignored -> new RegionCloudData());
+            if (AtmoCommonConfig.TELEMETRY_ENABLED.get() && !CLOUD_BIRTH_TICK.containsKey(sample.id())) {
+                CLOUD_BIRTH_TICK.put(sample.id(), level.getGameTime());
+                CLOUD_TYPES.put(sample.id(), sample.cloudType());
+                recordCloudCreated(level, sample);
+            }
+            if (AtmoCommonConfig.TELEMETRY_ENABLED.get()) {
+                CLOUD_LAST_POS.put(sample.id(), new Vector2i((int) sample.worldX(), (int) sample.worldZ()));
+                recordCloudTick(level, sample, data);
+            }
             data.updateFromSample(sample, region);
 
             for (RegionSample.Footprint footprint : sample.footprint()) {
@@ -297,6 +319,11 @@ public final class CloudManager {
             }
         }
 
+        if (AtmoCommonConfig.TELEMETRY_ENABLED.get()) {
+            REGION_DATA.keySet().stream()
+                    .filter(id -> !observed.contains(id))
+                    .forEach(id -> recordCloudDeath(level, id));
+        }
         pruneMissingRegions(observed);
         applyBiomeContributions(contributions);
     }
@@ -313,9 +340,15 @@ public final class CloudManager {
     private static void pruneMissingRegions(Set<Integer> observed) {
         if (observed.isEmpty()) {
             REGION_DATA.clear();
+            CLOUD_BIRTH_TICK.clear();
+            CLOUD_LAST_POS.clear();
+            CLOUD_TYPES.clear();
             return;
         }
         REGION_DATA.keySet().removeIf(id -> !observed.contains(id));
+        CLOUD_BIRTH_TICK.keySet().removeIf(id -> !observed.contains(id));
+        CLOUD_LAST_POS.keySet().removeIf(id -> !observed.contains(id));
+        CLOUD_TYPES.keySet().removeIf(id -> !observed.contains(id));
     }
 
     private static void applyBiomeContributions(Map<RegionInstanceKey, BiomeContribution> contributions) {
@@ -400,6 +433,7 @@ public final class CloudManager {
                 result -> {
                     try {
                         if (result.candidate() != null) {
+                            recordPrecipitationDecision(level, result.candidate());
                             spawnCandidate(level, generator, result.candidate());
                         }
                     } finally {
@@ -538,6 +572,95 @@ public final class CloudManager {
                 region,
                 candidate.stats().windVector()
         );
+    }
+
+    private static void recordCloudCreated(ServerLevel level, RegionSample sample) {
+        if (!AtmoCommonConfig.TELEMETRY_ENABLED.get()) {
+            return;
+        }
+        Vector2i lastPos = new Vector2i((int) sample.worldX(), (int) sample.worldZ());
+        String biomeId = sample.footprint().isEmpty() ? "unknown" : sample.footprint().get(0).key().toString();
+        TelemetryCollector.get().recordCloudEvent(new CloudCreated(
+                String.valueOf(sample.id()),
+                sample.cloudType().toString(),
+                "spawn_scan",
+                level.dimension().location().toString(),
+                lastPos.x() >> 4,
+                lastPos.y() >> 4,
+                level.getSeaLevel(),
+                sample.avgRainIntensity(),
+                sample.avgRainIntensity() > 0f,
+                biomeId
+        ));
+    }
+
+    private static void recordCloudTick(ServerLevel level, RegionSample sample, RegionCloudData data) {
+        if (!AtmoCommonConfig.TELEMETRY_ENABLED.get()) {
+            return;
+        }
+        Vector2i lastPos = new Vector2i((int) sample.worldX(), (int) sample.worldZ());
+        TelemetryCollector.get().recordCloudEvent(new CloudTickSummary(
+                String.valueOf(sample.id()),
+                lastPos.x() >> 4,
+                lastPos.y() >> 4,
+                0f,
+                data.getRainIntensity() > 0f,
+                data.getThickness(),
+                0f
+        ));
+    }
+
+    private static void recordCloudDeath(ServerLevel level, int id) {
+        if (!AtmoCommonConfig.TELEMETRY_ENABLED.get()) {
+            return;
+        }
+        long birth = CLOUD_BIRTH_TICK.getOrDefault(id, level.getGameTime());
+        Vector2i pos = CLOUD_LAST_POS.get(id);
+        TelemetryCollector.get().recordCloudEvent(new CloudDied(
+                String.valueOf(id),
+                pos == null ? 0 : pos.x() >> 4,
+                pos == null ? 0 : pos.y() >> 4,
+                (level.getGameTime() - birth) / 20f,
+                "despawn"
+        ));
+        CLOUD_BIRTH_TICK.remove(id);
+        CLOUD_LAST_POS.remove(id);
+        CLOUD_TYPES.remove(id);
+    }
+
+    private static void recordPrecipitationDecision(ServerLevel level, SpawnCandidate candidate) {
+        if (!AtmoCommonConfig.TELEMETRY_ENABLED.get() || candidate == null) {
+            return;
+        }
+        WeatherSampler.WeatherStats stats = candidate.stats();
+        if (stats == null) {
+            return;
+        }
+        List<String> passed = new ArrayList<>();
+        List<String> failed = new ArrayList<>();
+        if (stats.humidity() >= HUMIDITY_SPAWN_THRESHOLD_PERCENT) {
+            passed.add("humidity_threshold");
+        } else {
+            failed.add("humidity_threshold");
+        }
+        float dewPoint = calculateDewPoint(stats.temperature(), stats.humidity());
+        boolean allowed = failed.isEmpty();
+
+        TelemetryCollector.get().recordDecision(new PrecipitationDecisionTrace(
+                Instant.now(),
+                stats.dominantBiome().toString(),
+                stats.pos().getX() >> 4,
+                stats.pos().getZ() >> 4,
+                stats.temperature(),
+                stats.humidity(),
+                stats.pressure(),
+                dewPoint,
+                stats.stormFactor(),
+                allowed,
+                stats.humidity() / 100f,
+                passed,
+                failed
+        ));
     }
 
     private static String selectCloudId(int severity, boolean freezing) {

--- a/src/main/java/net/Gabou/projectatmosphere/modules/region/RegionForecastOrchestrator.java
+++ b/src/main/java/net/Gabou/projectatmosphere/modules/region/RegionForecastOrchestrator.java
@@ -4,7 +4,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
 import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.Gabou.projectatmosphere.telemetry.TelemetryCollector;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.ChannelSummary;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.DayCurve;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.ForecastSnapshot;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.Modifiers;
 import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
 import net.Gabou.projectatmosphere.util.RegionInstanceKey;
 import net.minecraft.core.BlockPos;
@@ -98,6 +104,9 @@ public final class RegionForecastOrchestrator {
         for (int i = 0; i < out.length; i++) {
             BiomeForecastSnapshot snap = biomeGenerator.generateSlice(biomes, i);
             float factor = Math.max(0f, biomeGenerator.factorForSlice(biomes, i));
+            if (AtmoCommonConfig.TELEMETRY_ENABLED.get() && snap != null) {
+                recordForecastSnapshot(snap, i);
+            }
             out[i] = new ForecastRegion.Section(factor, snap);
         }
         return out;
@@ -117,6 +126,57 @@ public final class RegionForecastOrchestrator {
             }
         }
         return result;
+    }
+
+    private static void recordForecastSnapshot(BiomeForecastSnapshot snap, int dayIndex) {
+        ChannelSummary temp = summarizeCurve(snap.temperatureCurve());
+        ChannelSummary humidity = summarizeCurve(snap.humidityCurve());
+        ChannelSummary pressure = summarizeCurve(snap.pressureCurve());
+        DayCurve curve = deriveDayCurve(snap.temperatureCurve());
+        ForecastSnapshot snapshot = new ForecastSnapshot(
+                snap.biomeKey().biomeType().toString(),
+                snap.biomeKey().samplePos() == null ? 0 : snap.biomeKey().samplePos().getX() >> 4,
+                snap.biomeKey().samplePos() == null ? 0 : snap.biomeKey().samplePos().getZ() >> 4,
+                dayIndex,
+                temp,
+                humidity,
+                pressure,
+                new ChannelSummary(0f, 0f),
+                curve,
+                new Modifiers(false, null, null, false, null)
+        );
+        TelemetryCollector.get().recordForecastSnapshot(snapshot);
+    }
+
+    private static ChannelSummary summarizeCurve(float[][] curve) {
+        if (curve == null || curve.length == 0) {
+            return new ChannelSummary(0f, 0f);
+        }
+        float min = Float.MAX_VALUE;
+        float max = -Float.MAX_VALUE;
+        for (float[] row : curve) {
+            if (row == null) {
+                continue;
+            }
+            for (float v : row) {
+                min = Math.min(min, v);
+                max = Math.max(max, v);
+            }
+        }
+        if (min == Float.MAX_VALUE) {
+            return new ChannelSummary(0f, 0f);
+        }
+        return new ChannelSummary(min, max);
+    }
+
+    private static DayCurve deriveDayCurve(float[][] curve) {
+        if (curve == null || curve.length == 0 || curve[0] == null || curve[0].length == 0) {
+            return new DayCurve(null, null, null, null);
+        }
+        float[] day = curve[0];
+        Float morning = day.length > 0 ? day[0] : null;
+        Float afternoon = day.length > 1 ? day[1] : null;
+        return new DayCurve(morning, afternoon, afternoon, morning);
     }
 
     public Vec3 toRegionLocal(BlockPos pos) {

--- a/src/main/java/net/Gabou/projectatmosphere/telemetry/ServerTelemetrySampler.java
+++ b/src/main/java/net/Gabou/projectatmosphere/telemetry/ServerTelemetrySampler.java
@@ -1,0 +1,115 @@
+package net.Gabou.projectatmosphere.telemetry;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.Gabou.projectatmosphere.ProjectAtmosphere;
+import net.Gabou.projectatmosphere.config.AtmoCommonConfig;
+import net.Gabou.projectatmosphere.manager.ForecastOrchestrator;
+import net.Gabou.projectatmosphere.modules.atmosphere.CloudManager;
+import net.Gabou.projectatmosphere.modules.core.WindVector;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.DominantBiomeOccupancy;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.OccupiedChunk;
+import net.Gabou.projectatmosphere.telemetry.TelemetryModels.PlayerExperienceSample;
+import net.Gabou.projectatmosphere.telemetry.TelemetryCollector;
+import net.Gabou.projectatmosphere.util.AtmosphereUtils;
+import net.Gabou.projectatmosphere.util.BiomeInstanceKey;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = ProjectAtmosphere.MODID)
+public final class ServerTelemetrySampler {
+    private static final Map<Long, Long> CHUNK_OCCUPANCY_TICKS = new LinkedHashMap<>();
+    private static final List<OccupiedChunk> TOP_BUFFER = new ArrayList<>(5);
+    private static final long SERVER_SESSION_START_MS = System.currentTimeMillis();
+
+    private ServerTelemetrySampler() {
+    }
+
+    @SubscribeEvent
+    public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
+        if (event.side.isClient() || event.phase != TickEvent.Phase.END) {
+            return;
+        }
+        if (!AtmoCommonConfig.TELEMETRY_ENABLED.get()) {
+            return;
+        }
+        if (!(event.player instanceof ServerPlayer player)) {
+            return;
+        }
+
+        ServerLevel level = player.serverLevel();
+        long gameTime = level.getGameTime();
+        BlockPos pos = player.blockPosition();
+
+        long key = chunkKey(pos.getX() >> 4, pos.getZ() >> 4);
+        CHUNK_OCCUPANCY_TICKS.merge(key, 1L, Long::sum);
+
+        if (gameTime % 200 == 0) {
+            recordPlayerSample(level, player, pos, gameTime);
+        }
+        if (gameTime % 1200 == 0) {
+            emitDominantBiomeOccupancy(gameTime);
+        }
+    }
+
+    private static void recordPlayerSample(ServerLevel level, ServerPlayer player, BlockPos pos, long gameTime) {
+        BiomeInstanceKey key = new BiomeInstanceKey(AtmosphereUtils.getBiomeLocation(pos, level), pos);
+        float temperature = ForecastOrchestrator.getCurrentTemperature(key, gameTime);
+        float humidity = ForecastOrchestrator.getCurrentHumidity(key, gameTime);
+        float pressure = ForecastOrchestrator.getCurrentPressure(key, gameTime);
+        WindVector wind = ForecastOrchestrator.getCurrentWind(key, gameTime);
+        boolean isRaining = CloudManager.get(level).isRainingAt(pos);
+        boolean temperatureOutOfRange = temperature < -60f || temperature > 60f;
+
+        PlayerExperienceSample sample = new PlayerExperienceSample(
+                gameTime / 24000L,
+                gameTime % 24000L,
+                (System.currentTimeMillis() - SERVER_SESSION_START_MS) / 1000L,
+                level.dimension().location().toString(),
+                pos.getX() >> 4,
+                pos.getZ() >> 4,
+                key.biomeType().toString(),
+                temperature,
+                humidity,
+                pressure,
+                wind.baseSpeed(),
+                wind.angleRadians(),
+                level.isRaining(),
+                level.isThundering(),
+                isRaining ? "RAINING" : "CLEAR",
+                temperatureOutOfRange,
+                false,
+                false
+        );
+        TelemetryCollector.get().recordPlayerSample(sample);
+    }
+
+    private static void emitDominantBiomeOccupancy(long gameTime) {
+        if (CHUNK_OCCUPANCY_TICKS.isEmpty()) {
+            return;
+        }
+        TOP_BUFFER.clear();
+        CHUNK_OCCUPANCY_TICKS.entrySet().stream()
+                .sorted(Map.Entry.<Long, Long>comparingByValue(Comparator.naturalOrder()).reversed())
+                .limit(5)
+                .forEach(entry -> {
+                    int cx = (int) (entry.getKey() >> 32);
+                    int cz = (int) (entry.getKey().longValue());
+                    long seconds = entry.getValue() / 20L;
+                    TOP_BUFFER.add(new OccupiedChunk(cx, cz, seconds));
+                });
+        TelemetryCollector.get().recordDominantBiome(new DominantBiomeOccupancy(gameTime / 24000L, List.copyOf(TOP_BUFFER)));
+    }
+
+    private static long chunkKey(int chunkX, int chunkZ) {
+        return ((long) chunkX << 32) | (chunkZ & 0xFFFFFFFFL);
+    }
+}


### PR DESCRIPTION
## Summary
- Collect client-side telemetry for player samples and dominant chunk occupancy to feed `/pa debug export`
- Record forecast snapshots, cloud lifecycle events, and precipitation gate decisions when telemetry is enabled
- Flag extreme-temperature anomalies and document the new telemetry coverage

## Testing
- `gradle build -q --console=plain` *(fails: JDK 17 toolchain not present in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69408fd3b9e08322a70cf3cf5dcc8ca2)